### PR TITLE
fix the test: format-utils-test-suite.cc and p4-controller-test-suite.cc

### DIFF
--- a/test/format-utils-test-suite.cc
+++ b/test/format-utils-test-suite.cc
@@ -158,10 +158,10 @@ FormatUtilsTestCase::TestHexCharToInt ()
 void
 FormatUtilsTestCase::TestHexStrToBytes ()
 {
-  NS_TEST_ASSERT_MSG_EQ (HexStrToBytes ("0x0a010001"), "\x0a\x01\x00\x01",
+  NS_TEST_ASSERT_MSG_EQ (HexStrToBytes ("0x0a010001"), (std::string ("\x0a\x01\x00\x01", 4)),
                          "HexStrToBytes failed for valid input");
 
-  NS_TEST_ASSERT_MSG_EQ (HexStrToBytes ("ff00"), "\xff\x00",
+  NS_TEST_ASSERT_MSG_EQ (HexStrToBytes ("ff00"), (std::string ("\xff\x00", 2)),
                          "HexStrToBytes failed for short input");
 
   NS_TEST_EXPECT_MSG_EQ (HexStrToBytes ("0x123"), "",
@@ -178,7 +178,7 @@ FormatUtilsTestCase::TestHexStrToBytes ()
 void
 FormatUtilsTestCase::TestIpStrToBytes ()
 {
-  NS_TEST_ASSERT_MSG_EQ (IpStrToBytes ("10.1.0.1"), "\x0a\x01\x00\x01",
+  NS_TEST_ASSERT_MSG_EQ (IpStrToBytes ("10.1.0.1"), (std::string ("\x0a\x01\x00\x01", 4)),
                          "IpStrToBytes failed for valid IP address");
 }
 
@@ -188,7 +188,7 @@ FormatUtilsTestCase::TestIpStrToBytes ()
 void
 FormatUtilsTestCase::TestUint32IpToHex ()
 {
-  NS_TEST_ASSERT_MSG_EQ (Uint32IpToHex (167772161), "0x0a010001",
+  NS_TEST_ASSERT_MSG_EQ (Uint32IpToHex (167837697), "0x0a010001",
                          "Uint32IpToHex failed for valid input");
   NS_TEST_ASSERT_MSG_EQ (Uint32IpToHex (0), "0x00000000", "Uint32IpToHex failed for zero input");
 }
@@ -199,7 +199,7 @@ FormatUtilsTestCase::TestUint32IpToHex ()
 void
 FormatUtilsTestCase::TestIntToBytes ()
 {
-  NS_TEST_ASSERT_MSG_EQ (IntToBytes ("123", 16), "\x00\x7b", "IntToBytes failed for 16-bit width");
+  NS_TEST_ASSERT_MSG_EQ (IntToBytes ("123", 16), (std::string ("\x00\x7b", 2)), "IntToBytes failed for 16-bit width");
   NS_TEST_ASSERT_MSG_EQ (IntToBytes ("255", 8), "\xff", "IntToBytes failed for 8-bit width");
 }
 

--- a/test/p4-controller-test-suite.cc
+++ b/test/p4-controller-test-suite.cc
@@ -7,6 +7,7 @@
 #include "ns3/p4-core-v1model.h"
 #include "ns3/p4-helper.h"
 #include "ns3/p4-topology-reader-helper.h"
+#include "ns3/format-utils.h"
 #include "ns3/test.h"
 
 using namespace ns3;
@@ -41,9 +42,13 @@ void P4ControllerCheckFlowEntryTestCase::DoRun() {
   // std::string appDataRate = "3Mbps"; // Default application data rate
   // std::string ns3_link_rate = "1000Mbps";
 
+  std::string p4SrcDir = GetP4ExamplePath() + "/simple_v1model";
+  std::string p4JsonPath = p4SrcDir + "/simple_v1model.json";
+  std::string flowTablePath = p4SrcDir + "/flowtable_0.txt";
+  std::string topoInput = p4SrcDir + "/topo.txt";
+
   P4TopologyReaderHelper p4TopoHelper;
-  p4TopoHelper.SetFileName("/home/p4/workdir/ns3.39/contrib/p4sim/examples/"
-                           "p4src/simple_v1model/topo.txt");
+  p4TopoHelper.SetFileName(topoInput);
   p4TopoHelper.SetFileType("CsmaTopo");
 
   // Get the topology reader, and read the file, load in the m_linksList.
@@ -74,11 +79,9 @@ void P4ControllerCheckFlowEntryTestCase::DoRun() {
   // Set up the P4 switch helper
   P4Helper p4Helper;
   p4Helper.SetDeviceAttribute(
-      "JsonPath", StringValue("/home/p4/workdir/ns3.39/contrib/p4sim/test/"
-                              "p4src/simple_v1model/simple_v1model.json"));
+      "JsonPath", StringValue(p4JsonPath));
   p4Helper.SetDeviceAttribute(
-      "FlowTablePath", StringValue("/home/p4/workdir/ns3.39/contrib/p4sim/test/"
-                                   "p4src/simple_v1model/flowtable_0.txt"));
+      "FlowTablePath", StringValue(flowTablePath));
   p4Helper.SetDeviceAttribute("ChannelType", UintegerValue(0));
   p4Helper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0)); // v1model
 
@@ -164,10 +167,15 @@ void P4ControllerCheckFlowEntryTestCase::DoRun() {
 void P4ControllerActionProfileTestCase::DoRun() {
   // std::string appDataRate = "3Mbps"; // Default application data rate
   // std::string ns3_link_rate = "1000Mbps";
+  
+  std::string p4SrcDir = GetP4TestPath() + "/action_profile_v1model";
+  std::string p4JsonPath = p4SrcDir + "/action-profile.json";
+  
+  std::string flowTablePath = p4SrcDir + "/flowtable_0.txt";
+  std::string topoInput = p4SrcDir + "/topo.txt";
 
   P4TopologyReaderHelper p4TopoHelper;
-  p4TopoHelper.SetFileName("/home/p4/workdir/ns3.39/contrib/p4sim/examples/"
-                           "p4src/simple_v1model/topo.txt");
+  p4TopoHelper.SetFileName(topoInput);
   p4TopoHelper.SetFileType("CsmaTopo");
 
   // Get the topology reader, and read the file, load in the m_linksList.
@@ -199,11 +207,9 @@ void P4ControllerActionProfileTestCase::DoRun() {
   P4Helper p4Helper;
   p4Helper.SetDeviceAttribute(
       "JsonPath",
-      StringValue("/home/p4/workdir/ns3.39/contrib/p4sim/test/p4src/"
-                  "action_profile_v1model/action-profile.json"));
+      StringValue(p4JsonPath));
   p4Helper.SetDeviceAttribute(
-      "FlowTablePath", StringValue("/home/p4/workdir/ns3.39/contrib/p4sim/test/"
-                                   "p4src/simple_v1model/flowtable_0.txt"));
+      "FlowTablePath", StringValue(flowTablePath));
   p4Helper.SetDeviceAttribute("ChannelType", UintegerValue(0));
   p4Helper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0)); // v1model
 

--- a/test/p4src/action_profile_v1model/flowtable_0.txt
+++ b/test/p4src/action_profile_v1model/flowtable_0.txt
@@ -1,0 +1,6 @@
+table_set_default ipv4_nhop drop
+table_set_default arp_simple drop
+table_add ipv4_nhop ipv4_forward 0x0a010101 => 00:00:00:00:00:01 0x0
+table_add arp_simple set_arp_nhop 0x0a010101 => 0x0
+table_add ipv4_nhop ipv4_forward 0x0a010102 => 00:00:00:00:00:03 0x1
+table_add arp_simple set_arp_nhop 0x0a010102 => 0x1

--- a/test/p4src/action_profile_v1model/topo.txt
+++ b/test/p4src/action_profile_v1model/topo.txt
@@ -1,0 +1,4 @@
+1 2 2
+1 h 0 s 1000Mbps 0.1ms
+2 h 0 s 1000Mbps 0.1ms
+0 BASIC

--- a/utils/format-utils.cc
+++ b/utils/format-utils.cc
@@ -330,21 +330,22 @@ IntToBytes(const std::string& inputStr, int bitWidth)
     std::vector<unsigned int> byte_array;
     std::string res;
     unsigned int input_num = std::stoi(inputStr); // assume decimal 10
+    int byteWidth = (bitWidth + 7) / 8;
 
     while (input_num > 0)
     {
         byte_array.push_back(input_num % 256);
         input_num = input_num / 256;
-        bitWidth--;
+        byteWidth--;
     }
-    if (bitWidth < 0)
+    if (byteWidth < 0)
     {
         std::cout << "UIn_BadParamError: too large parameter!" << std::endl;
     }
-    while (bitWidth > 0)
+    while (byteWidth > 0)
     {
         byte_array.push_back(0);
-        bitWidth--;
+        byteWidth--;
     }
     std::reverse(byte_array.begin(), byte_array.end());
 
@@ -406,5 +407,12 @@ GetP4ExamplePath()
 {
     return GetP4SimDir() + "/examples/p4src";
 }
+
+std::string
+GetP4TestPath()
+{
+    return GetP4SimDir() + "/test/p4src";
+}
+
 
 } // namespace ns3

--- a/utils/format-utils.h
+++ b/utils/format-utils.h
@@ -212,6 +212,21 @@ std::string GetP4SimDir();
  */
 std::string GetP4ExamplePath();
 
+/**
+ * @brief Get the path to the P4Sim test/p4src directory.
+ *
+ * Convenience function that returns GetP4SimDir() + "/test/p4src".
+ * Use this as a base path and append specific test subdirectories.
+ *
+ * Example:
+ *   GetP4TestPath() => "/home/user/ns3/contrib/p4sim/test/p4src"
+ *   GetP4TestPath() + "/simple_v1model" => ".../p4src/simple_v1model"
+ *
+ * @return The full absolute path to test/p4src.
+ */
+std::string
+GetP4TestPath();
+
 } // namespace ns3
 
 #endif /* FORMAT_UTILS_H */


### PR DESCRIPTION
1. For `p4-controller-test-suite.cc`: Update the `` with a new path function `GetP4TestPath()` for test cases. 
2. For `format-utils-test-suite.cc`: Fix the bugs, because we changed `format-utils.h` and the old test scripts do not work.

Test the 5 test cases, and the **result**:
```bash
(p4dev-python-venv) mm@mm-virtualbox:~/ns3.39$ python3 test.py -s p4sim
[1/1] PASS: TestSuite p4sim
1 of 1 tests passed (1 passed, 0 skipped, 0 failed, 0 crashed, 0 valgrind errors)
(p4dev-python-venv) mm@mm-virtualbox:~/ns3.39$ python3 test.py -s p4-topology-reader
[1/1] PASS: TestSuite p4-topology-reader
1 of 1 tests passed (1 passed, 0 skipped, 0 failed, 0 crashed, 0 valgrind errors)
(p4dev-python-venv) mm@mm-virtualbox:~/ns3.39$ python3 test.py -s format-utils
[1/1] PASS: TestSuite format-utils
1 of 1 tests passed (1 passed, 0 skipped, 0 failed, 0 crashed, 0 valgrind errors)
(p4dev-python-venv) mm@mm-virtualbox:~/ns3.39$ python3 test.py -s p4-controller
[1/1] PASS: TestSuite p4-controller
1 of 1 tests passed (1 passed, 0 skipped, 0 failed, 0 crashed, 0 valgrind errors)
```