### PR TITLE
P4switchNetDevice send to ns3 packet from eth header

### DIFF
--- a/examples/p4-calc.cc
+++ b/examples/p4-calc.cc
@@ -106,16 +106,18 @@ DecodeP4CalcFrame(Ptr<const Packet> packet)
     uint32_t opB = ReadBe32(&calcBytes[8]);
     uint32_t result = ReadBe32(&calcBytes[12]);
 
-    NS_LOG_INFO("P4Calc RX: op=0x" << std::hex << static_cast<uint32_t>(op) << std::dec
-                                   << " opA=" << opA << " opB=" << opB << " result=" << result);
+    NS_LOG_INFO("P4Calc RX : op = 0x " << std::hex << static_cast<uint32_t>(op) << std::dec
+                                       << " opA=" << opA << " opB=" << opB << " result=" << result);
 }
 
 void
-SendTestPacket(Ptr<NetDevice> sender, Ptr<Packet> packet, Address dst, uint16_t protocol)
+SendTestPacket(Ptr<NetDevice> sender,
+               Ptr<Packet> packet,
+               Mac48Address src,
+               Mac48Address dst,
+               uint16_t protocol)
 {
-    bool ok = sender->Send(packet, dst, protocol);
-    NS_LOG_INFO("SendTestPacket status=" << ok << ", dst=" << ConvertMacToHex(dst)
-                                         << ", protocol=0x" << std::hex << protocol);
+    sender->SendFrom(packet, src, dst, protocol);
 }
 
 // ============================ data struct ============================
@@ -378,14 +380,15 @@ main(int argc, char* argv[])
     Ptr<NetDevice> switchIngressDevice =
         switchNodes[hostNodes[0].linkSwitchIndex].switchDevices.Get(hostNodes[0].linkSwitchPort);
 
-    hostTxDevice->TraceConnectWithoutContext("PromiscSniffer", MakeCallback(&DecodeP4CalcFrame));
+    hostTxDevice->TraceConnectWithoutContext("MacRx", MakeCallback(&DecodeP4CalcFrame));
 
     // Send from host 0 to switch after simulation starts.
     Simulator::Schedule(Seconds(global_start_time + 0.1),
                         &SendTestPacket,
                         hostTxDevice,
                         testPacket->Copy(),
-                        switchIngressDevice->GetAddress(),
+                        Mac48Address::ConvertFrom(hostTxDevice->GetAddress()),
+                        Mac48Address::ConvertFrom(switchIngressDevice->GetAddress()),
                         static_cast<uint16_t>(0x1234));
 
     Simulator::Stop(Seconds(global_stop_time));

--- a/examples/p4src/calc/flowtable_0.txt
+++ b/examples/p4src/calc/flowtable_0.txt
@@ -1,6 +1,1 @@
 table_set_default calculate operation_drop
-table_add calculate operation_add 0x2b =>
-table_add calculate operation_sub 0x2d =>
-table_add calculate operation_and 0x26 =>
-table_add calculate operation_or 0x7c =>
-table_add calculate operation_xor 0x5e =>

--- a/model/p4-switch-net-device.cc
+++ b/model/p4-switch-net-device.cc
@@ -469,11 +469,17 @@ void P4SwitchNetDevice::SendNs3Packet(Ptr<Packet> packetOut, int outPort,
     // std::cout << "* Switch Port (out)*** Send from Device: " << std::endl;
     // packetOut->Print(std::cout);
     // std::cout << "packet length: " << packetOut->GetSize() << std::endl;
+    Address src = eeh_1.GetSource();
+    Address dst = eeh_1.GetDestination();
+    NS_LOG_DEBUG("* Reconstructed Ethernet header: Source MAC: "
+                 << Mac48Address::ConvertFrom(src)
+                 << ", Destination MAC: " << Mac48Address::ConvertFrom(dst)
+                 << ", Protocol: 0x" << std::hex << protocol << std::dec);
 
     if (outPort != 511) {
       NS_LOG_DEBUG("EgressPortNum: " << outPort);
       Ptr<NetDevice> outNetDevice = GetBridgePort(outPort);
-      outNetDevice->Send(packetOut, destination, protocol);
+      outNetDevice->SendFrom(packetOut, src, dst, protocol);
     }
   } else
     NS_LOG_DEBUG("Null Packet!");


### PR DESCRIPTION
P4 Switch NetDevice uses Send() while converting packet to ns3 and send to ns3 device, disregards the existing ethernet header and the addresses. The update looks into the ethernet header and and sends the packet according to the address existing in the header