### PR TITLE
Fix the issue where the  parameter is left unset, and add tracing at …

### DIFF
--- a/examples/p4-basic-controller.cc
+++ b/examples/p4-basic-controller.cc
@@ -53,7 +53,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE("P4BasicControllerExample");
+NS_LOG_COMPONENT_DEFINE("P4BasicController");
 
 unsigned long start = getTickCount();
 double global_start_time = 1.0;
@@ -75,375 +75,390 @@ uint64_t totalTxBytes = 0;
 uint64_t totalRxBytes = 0;
 
 // Convert IP address to hexadecimal format
-std::string ConvertIpToHex(Ipv4Address ipAddr) {
-  std::ostringstream hexStream;
-  uint32_t ip = ipAddr.Get(); // Get the IP address as a 32-bit integer
-  hexStream << "0x" << std::hex << std::setfill('0') << std::setw(2)
-            << ((ip >> 24) & 0xFF)                 // First byte
-            << std::setw(2) << ((ip >> 16) & 0xFF) // Second byte
-            << std::setw(2) << ((ip >> 8) & 0xFF)  // Third byte
-            << std::setw(2) << (ip & 0xFF);        // Fourth byte
-  return hexStream.str();
+std::string
+ConvertIpToHex(Ipv4Address ipAddr)
+{
+    std::ostringstream hexStream;
+    uint32_t ip = ipAddr.Get(); // Get the IP address as a 32-bit integer
+    hexStream << "0x" << std::hex << std::setfill('0') << std::setw(2)
+              << ((ip >> 24) & 0xFF)                 // First byte
+              << std::setw(2) << ((ip >> 16) & 0xFF) // Second byte
+              << std::setw(2) << ((ip >> 8) & 0xFF)  // Third byte
+              << std::setw(2) << (ip & 0xFF);        // Fourth byte
+    return hexStream.str();
 }
 
 // Convert MAC address to hexadecimal format
-std::string ConvertMacToHex(Address macAddr) {
-  std::ostringstream hexStream;
-  Mac48Address mac =
-      Mac48Address::ConvertFrom(macAddr); // Convert Address to Mac48Address
-  uint8_t buffer[6];
-  mac.CopyTo(buffer); // Copy MAC address bytes into buffer
+std::string
+ConvertMacToHex(Address macAddr)
+{
+    std::ostringstream hexStream;
+    Mac48Address mac = Mac48Address::ConvertFrom(macAddr); // Convert Address to Mac48Address
+    uint8_t buffer[6];
+    mac.CopyTo(buffer); // Copy MAC address bytes into buffer
 
-  hexStream << "0x";
-  for (int i = 0; i < 6; ++i) {
-    hexStream << std::hex << std::setfill('0') << std::setw(2)
-              << static_cast<int>(buffer[i]);
-  }
-  return hexStream.str();
-}
-
-void TxCallback(Ptr<const Packet> packet) {
-  if (first_tx) {
-    // here we just simple jump the first 10 pkts (include some of ARP packets)
-    first_packet_send_time_tx = Simulator::Now().GetSeconds();
-    counter_sender_10--;
-    if (counter_sender_10 == 0) {
-      first_tx = false;
+    hexStream << "0x";
+    for (int i = 0; i < 6; ++i)
+    {
+        hexStream << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(buffer[i]);
     }
-  } else {
-    totalTxBytes += packet->GetSize();
-    last_packet_send_time_tx = Simulator::Now().GetSeconds();
-  }
+    return hexStream.str();
 }
 
-void RxCallback(Ptr<const Packet> packet, const Address &addr) {
-  if (first_rx) {
-    // here we just simple jump the first 10 pkts (include some of ARP packets)
-    first_packet_received_time_rx = Simulator::Now().GetSeconds();
-    counter_receiver_10--;
-    if (counter_receiver_10 == 0) {
-      first_rx = false;
+void
+TxCallback(Ptr<const Packet> packet)
+{
+    if (first_tx)
+    {
+        // here we just simple jump the first 10 pkts (include some of ARP packets)
+        first_packet_send_time_tx = Simulator::Now().GetSeconds();
+        counter_sender_10--;
+        if (counter_sender_10 == 0)
+        {
+            first_tx = false;
+        }
     }
-  } else {
-    totalRxBytes += packet->GetSize();
-    last_packet_received_time_rx = Simulator::Now().GetSeconds();
-  }
+    else
+    {
+        totalTxBytes += packet->GetSize();
+        last_packet_send_time_tx = Simulator::Now().GetSeconds();
+    }
 }
 
-void PrintFinalThroughput() {
-  double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
-  double elapsed_time =
-      last_packet_received_time_rx - first_packet_received_time_rx;
+void
+RxCallback(Ptr<const Packet> packet, const Address& addr)
+{
+    if (first_rx)
+    {
+        // here we just simple jump the first 10 pkts (include some of ARP packets)
+        first_packet_received_time_rx = Simulator::Now().GetSeconds();
+        counter_receiver_10--;
+        if (counter_receiver_10 == 0)
+        {
+            first_rx = false;
+        }
+    }
+    else
+    {
+        totalRxBytes += packet->GetSize();
+        last_packet_received_time_rx = Simulator::Now().GetSeconds();
+    }
+}
 
-  double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-  double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-  std::cout << "client_start_time: " << first_packet_send_time_tx
-            << "client_stop_time: " << last_packet_send_time_tx
-            << "sink_start_time: " << first_packet_received_time_rx
-            << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+void
+PrintFinalThroughput()
+{
+    double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
+    double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
-  std::cout << "======================================" << std::endl;
-  std::cout << "Final Simulation Results:" << std::endl;
-  std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time "
-            << send_time << std::endl;
-  std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time "
-            << elapsed_time << std::endl;
-  std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps"
-            << std::endl;
-  std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps"
-            << std::endl;
-  std::cout << "======================================" << std::endl;
+    double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
+    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
+    std::cout << "client_start_time: " << first_packet_send_time_tx
+              << "client_stop_time: " << last_packet_send_time_tx
+              << "sink_start_time: " << first_packet_received_time_rx
+              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+
+    std::cout << "======================================" << std::endl;
+    std::cout << "Final Simulation Results:" << std::endl;
+    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
+              << std::endl;
+    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
+              << std::endl;
+    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
+    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "======================================" << std::endl;
 }
 
 // ============================ data struct ============================
-struct SwitchNodeC_t {
-  NetDeviceContainer switchDevices;
-  std::vector<std::string> switchPortInfos;
+struct SwitchNodeC_t
+{
+    NetDeviceContainer switchDevices;
+    std::vector<std::string> switchPortInfos;
 };
 
-struct HostNodeC_t {
-  NetDeviceContainer hostDevice;
-  Ipv4InterfaceContainer hostIpv4;
-  unsigned int linkSwitchIndex;
-  unsigned int linkSwitchPort;
-  std::string hostIpv4Str;
+struct HostNodeC_t
+{
+    NetDeviceContainer hostDevice;
+    Ipv4InterfaceContainer hostIpv4;
+    unsigned int linkSwitchIndex;
+    unsigned int linkSwitchPort;
+    std::string hostIpv4Str;
 };
 
-int main(int argc, char *argv[]) {
-  LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
-  LogComponentEnable("P4Controller", LOG_LEVEL_INFO);
-  LogComponentEnable("P4CoreV1model", LOG_LEVEL_WARN);
+int
+main(int argc, char* argv[])
+{
+    LogComponentEnable("P4BasicController", LOG_LEVEL_INFO);
+    LogComponentEnable("P4CoreV1model", LOG_LEVEL_WARN);
 
-  // ============================ parameters ============================
-  int running_number = 0;
-  uint16_t pktSize = 1000; // in Bytes. 1458 to prevent fragments, default 512
-  std::string appDataRate = "3Mbps"; // Default application data rate
-  std::string ns3_link_rate = "1000Mbps";
-  bool enableTracePcap = true;
+    // ============================ parameters ============================
+    uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments, default 512
+    std::string appDataRate = "3Mbps"; // Default application data rate
+    std::string ns3_link_rate = "1000Mbps";
+    bool enableTracePcap = true;
 
-  // Use P4SIM_DIR environment variable for portable paths
-  std::string p4SrcDir = GetP4ExamplePath() + "/p4_basic";
-  std::string p4JsonPath = p4SrcDir + "/p4_basic.json";
-  std::string flowTableDirPath = p4SrcDir + "/";
-  std::string topoInput = p4SrcDir + "/topo.txt";
-  std::string topoFormat("CsmaTopo");
+    // Use P4SIM_DIR environment variable for portable paths
+    std::string p4SrcDir = GetP4ExamplePath() + "/p4_basic";
+    std::string p4JsonPath = p4SrcDir + "/p4_basic.json";
+    std::string flowTableDirPath = p4SrcDir + "/";
+    std::string topoInput = p4SrcDir + "/topo.txt";
+    std::string topoFormat("CsmaTopo");
 
-  // ============================  command line ============================
-  CommandLine cmd;
-  cmd.AddValue("runnum", "running number in loops", running_number);
-  cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
-  cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)",
-               appDataRate);
-  cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]",
-               enableTracePcap);
-  cmd.Parse(argc, argv);
+    // ============================  command line ============================
+    CommandLine cmd;
+    cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
+    cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
+    cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
+    cmd.Parse(argc, argv);
 
-  // ============================ topo -> network ============================
-  P4TopologyReaderHelper p4TopoHelper;
-  p4TopoHelper.SetFileName(topoInput);
-  p4TopoHelper.SetFileType(topoFormat);
-  NS_LOG_INFO("*** Reading topology from file: "
-              << topoInput << " with format: " << topoFormat);
+    // ============================ topo -> network ============================
+    P4TopologyReaderHelper p4TopoHelper;
+    p4TopoHelper.SetFileName(topoInput);
+    p4TopoHelper.SetFileType(topoFormat);
+    NS_LOG_INFO("*** Reading topology from file: " << topoInput << " with format: " << topoFormat);
 
-  // Get the topology reader, and read the file, load in the m_linksList.
-  Ptr<P4TopologyReader> topoReader = p4TopoHelper.GetTopologyReader();
+    // Get the topology reader, and read the file, load in the m_linksList.
+    Ptr<P4TopologyReader> topoReader = p4TopoHelper.GetTopologyReader();
 
-  topoReader->PrintTopology();
+    topoReader->PrintTopology();
 
-  if (topoReader->LinksSize() == 0) {
-    NS_LOG_ERROR("Problems reading the topology file. Failing.");
-    return -1;
-  }
+    if (topoReader->LinksSize() == 0)
+    {
+        NS_LOG_ERROR("Problems reading the topology file. Failing.");
+        return -1;
+    }
 
-  // get switch and host node
-  NodeContainer terminals = topoReader->GetHostNodeContainer();
-  NodeContainer switchNode = topoReader->GetSwitchNodeContainer();
+    // get switch and host node
+    NodeContainer terminals = topoReader->GetHostNodeContainer();
+    NodeContainer switchNode = topoReader->GetSwitchNodeContainer();
 
-  const unsigned int hostNum = terminals.GetN();
-  const unsigned int switchNum = switchNode.GetN();
-  NS_LOG_INFO("*** Host number: " << hostNum
-                                  << ", Switch number: " << switchNum);
+    const unsigned int hostNum = terminals.GetN();
+    const unsigned int switchNum = switchNode.GetN();
+    NS_LOG_INFO("*** Host number: " << hostNum << ", Switch number: " << switchNum);
 
-  // set default network link parameter
-  CsmaHelper csma;
-  csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
-  csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
+    // set default network link parameter
+    CsmaHelper csma;
+    csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
+    csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-  // NetDeviceContainer hostDevices;
-  // NetDeviceContainer switchDevices;
-  P4TopologyReader::ConstLinksIterator_t iter;
-  SwitchNodeC_t switchNodes[switchNum];
-  HostNodeC_t hostNodes[hostNum];
-  unsigned int fromIndex, toIndex;
-  std::string dataRate, delay;
-  for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd();
-       iter++) {
-    if (iter->GetAttributeFailSafe("DataRate", dataRate))
-      csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-    if (iter->GetAttributeFailSafe("Delay", delay))
-      csma.SetChannelAttribute("Delay", StringValue(delay));
+    // NetDeviceContainer hostDevices;
+    // NetDeviceContainer switchDevices;
+    P4TopologyReader::ConstLinksIterator_t iter;
+    SwitchNodeC_t switchNodes[switchNum];
+    HostNodeC_t hostNodes[hostNum];
+    unsigned int fromIndex, toIndex;
+    std::string dataRate, delay;
+    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
+    {
+        if (iter->GetAttributeFailSafe("DataRate", dataRate))
+            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
+        if (iter->GetAttributeFailSafe("Delay", delay))
+            csma.SetChannelAttribute("Delay", StringValue(delay));
 
-    fromIndex = iter->GetFromIndex();
-    toIndex = iter->GetToIndex();
-    NetDeviceContainer link =
-        csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
+        fromIndex = iter->GetFromIndex();
+        toIndex = iter->GetToIndex();
+        NetDeviceContainer link =
+            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
 
-    if (iter->GetFromType() == 's' && iter->GetToType() == 's') {
-      NS_LOG_INFO("*** Link from  switch "
-                  << fromIndex << " to  switch " << toIndex
-                  << " with data rate " << dataRate << " and delay " << delay);
+        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
+        {
+            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
+                                                 << " with data rate " << dataRate << " and delay "
+                                                 << delay);
 
-      unsigned int fromSwitchPortNumber =
-          switchNodes[fromIndex].switchDevices.GetN();
-      unsigned int toSwitchPortNumber =
-          switchNodes[toIndex].switchDevices.GetN();
-      switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-      switchNodes[fromIndex].switchPortInfos.push_back(
-          "s" + UintToString(toIndex) + "_" + UintToString(toSwitchPortNumber));
+            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
+            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
+            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
+                                                             UintToString(toSwitchPortNumber));
 
-      switchNodes[toIndex].switchDevices.Add(link.Get(1));
-      switchNodes[toIndex].switchPortInfos.push_back(
-          "s" + UintToString(fromIndex) + "_" +
-          UintToString(fromSwitchPortNumber));
-    } else {
-      if (iter->GetFromType() == 's' && iter->GetToType() == 'h') {
-        NS_LOG_INFO("*** Link from switch "
-                    << fromIndex << " to  host" << toIndex << " with data rate "
-                    << dataRate << " and delay " << delay);
-
-        unsigned int fromSwitchPortNumber =
-            switchNodes[fromIndex].switchDevices.GetN();
-        switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-        switchNodes[fromIndex].switchPortInfos.push_back(
-            "h" + UintToString(toIndex - switchNum));
-
-        hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-        hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-        hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-      } else {
-        if (iter->GetFromType() == 'h' && iter->GetToType() == 's') {
-          NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch"
-                                            << toIndex << " with data rate "
-                                            << dataRate << " and delay "
-                                            << delay);
-          unsigned int toSwitchPortNumber =
-              switchNodes[toIndex].switchDevices.GetN();
-          switchNodes[toIndex].switchDevices.Add(link.Get(1));
-          switchNodes[toIndex].switchPortInfos.push_back(
-              "h" + UintToString(fromIndex - switchNum));
-
-          hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-          hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-          hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-        } else {
-          NS_LOG_ERROR("link error!");
-          abort();
+            switchNodes[toIndex].switchDevices.Add(link.Get(1));
+            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
+                                                           UintToString(fromSwitchPortNumber));
         }
-      }
+        else
+        {
+            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
+            {
+                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
+                                                    << " with data rate " << dataRate
+                                                    << " and delay " << delay);
+
+                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
+                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+                switchNodes[fromIndex].switchPortInfos.push_back("h" +
+                                                                 UintToString(toIndex - switchNum));
+
+                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
+                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
+                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
+            }
+            else
+            {
+                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
+                {
+                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
+                                                      << " with data rate " << dataRate
+                                                      << " and delay " << delay);
+                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
+                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
+                    switchNodes[toIndex].switchPortInfos.push_back(
+                        "h" + UintToString(fromIndex - switchNum));
+
+                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
+                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
+                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
+                }
+                else
+                {
+                    NS_LOG_ERROR("link error!");
+                    abort();
+                }
+            }
+        }
     }
-  }
 
-  // ========================Print the Channel Type and NetDevice
-  // Type========================
+    // ========================Print the Channel Type and NetDevice
+    // Type========================
 
-  InternetStackHelper internet;
-  internet.Install(terminals);
-  internet.Install(switchNode);
+    InternetStackHelper internet;
+    internet.Install(terminals);
+    internet.Install(switchNode);
 
-  Ipv4AddressHelper ipv4;
-  ipv4.SetBase("10.1.1.0", "255.255.255.0");
-  std::vector<Ipv4InterfaceContainer> terminalInterfaces(hostNum);
-  std::vector<std::string> hostIpv4(hostNum);
+    Ipv4AddressHelper ipv4;
+    ipv4.SetBase("10.1.1.0", "255.255.255.0");
+    std::vector<Ipv4InterfaceContainer> terminalInterfaces(hostNum);
+    std::vector<std::string> hostIpv4(hostNum);
 
-  for (unsigned int i = 0; i < hostNum; i++) {
-    terminalInterfaces[i] = ipv4.Assign(terminals.Get(i)->GetDevice(0));
-    hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
-  }
-
-  //===============================  Print IP and MAC
-  //addresses===============================
-  NS_LOG_INFO("Node IP and MAC addresses:");
-  for (uint32_t i = 0; i < terminals.GetN(); ++i) {
-    Ptr<Node> node = terminals.Get(i);
-    Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-    Ptr<NetDevice> netDevice = node->GetDevice(0);
-
-    // Get the IP address
-    Ipv4Address ipAddr =
-        ipv4->GetAddress(1, 0).GetLocal(); // Interface index 1 corresponds to
-                                           // the first assigned IP
-
-    // Get the MAC address
-    Ptr<NetDevice> device =
-        node->GetDevice(0); // Assuming the first device is the desired one
-    Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
-
-    NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
-
-    // Convert to hexadecimal
-    std::string ipHex = ConvertIpToHex(ipAddr);
-    std::string macHex = ConvertMacToHex(mac);
-    NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
-  }
-
-  // Bridge or P4 switch configuration
-  P4Helper p4SwitchHelper;
-  p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
-  p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(0));
-  p4SwitchHelper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0));
-
-  P4Controller controller;
-
-  for (unsigned int i = 0; i < switchNum; i++) {
-    std::string flowTablePath =
-        flowTableDirPath + "flowtable_" + std::to_string(i) + ".txt";
-    p4SwitchHelper.SetDeviceAttribute("FlowTablePath",
-                                      StringValue(flowTablePath));
-    NS_LOG_INFO("*** P4 switch configuration: " << p4JsonPath << ", \n "
-                                                << flowTablePath);
-
-    NetDeviceContainer p4SwitchNetDeviceContainer =
-        p4SwitchHelper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
-
-    for (uint32_t j = 0; j < p4SwitchNetDeviceContainer.GetN(); j++) {
-      Ptr<P4SwitchNetDevice> p4sw =
-          DynamicCast<P4SwitchNetDevice>(p4SwitchNetDeviceContainer.Get(j));
-      if (p4sw) {
-        controller.RegisterSwitch(p4sw);
-        controller.ConnectToSwitchEvents(0); // connect early
-
-        Simulator::Schedule(Seconds(2.0), [&controller]() {
-          controller.PrintTableEntryCount(0, "MyIngress.ipv4_nhop");
-        });
-
-        Simulator::Schedule(Seconds(3.0), [&controller]() {
-          controller.PrintFlowEntries(0, "MyIngress.ipv4_nhop");
-        });
-
-        Simulator::Schedule(Seconds(4.0), [&, p4sw]() {
-          p4sw->EmitSwitchEvent(0, "Hello world from test event");
-        });
-      } else {
-        NS_LOG_WARN("Failed to cast device at index "
-                    << j << " to P4SwitchNetDevice");
-      }
+    for (unsigned int i = 0; i < hostNum; i++)
+    {
+        terminalInterfaces[i] = ipv4.Assign(terminals.Get(i)->GetDevice(0));
+        hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
     }
-  }
 
-  // === Configuration for Link: h0 -----> h1 ===
-  unsigned int serverI = 3;
-  unsigned int clientI = 0;
-  uint16_t servPort = 9093; // UDP port for the server
+    //===============================  Print IP and MAC
+    // addresses===============================
+    NS_LOG_INFO("Node IP and MAC addresses:");
+    for (uint32_t i = 0; i < terminals.GetN(); ++i)
+    {
+        Ptr<Node> node = terminals.Get(i);
+        Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
+        Ptr<NetDevice> netDevice = node->GetDevice(0);
 
-  // === Retrieve Server Address ===
-  Ptr<Node> node = terminals.Get(serverI);
-  Ptr<Ipv4> ipv4_adder = node->GetObject<Ipv4>();
-  Ipv4Address serverAddr1 = ipv4_adder->GetAddress(1, 0).GetLocal();
-  InetSocketAddress dst1 = InetSocketAddress(serverAddr1, servPort);
+        // Get the IP address
+        Ipv4Address ipAddr = ipv4->GetAddress(1, 0).GetLocal(); // Interface index 1 corresponds to
+                                                                // the first assigned IP
 
-  // === Setup Packet Sink on Server ===
-  PacketSinkHelper sink1("ns3::UdpSocketFactory", dst1);
-  ApplicationContainer sinkApp1 = sink1.Install(terminals.Get(serverI));
-  sinkApp1.Start(Seconds(sink_start_time));
-  sinkApp1.Stop(Seconds(sink_stop_time));
+        // Get the MAC address
+        Ptr<NetDevice> device = node->GetDevice(0); // Assuming the first device is the desired one
+        Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
 
-  // === Setup OnOff Application on Client ===
-  OnOffHelper onOff1("ns3::UdpSocketFactory", dst1);
-  onOff1.SetAttribute("PacketSize", UintegerValue(pktSize));
-  onOff1.SetAttribute("DataRate", StringValue(appDataRate));
-  onOff1.SetAttribute("OnTime",
-                      StringValue("ns3::ConstantRandomVariable[Constant=1]"));
-  onOff1.SetAttribute("OffTime",
-                      StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
 
-  ApplicationContainer app1 = onOff1.Install(terminals.Get(clientI));
-  app1.Start(Seconds(client_start_time));
-  app1.Stop(Seconds(client_stop_time));
+        // Convert to hexadecimal
+        std::string ipHex = ConvertIpToHex(ipAddr);
+        std::string macHex = ConvertMacToHex(mac);
+        NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
+    }
 
-  // === Setup Tracing ===
-  Ptr<OnOffApplication> ptr_app1 =
-      DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
-  ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-  sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+    // Bridge or P4 switch configuration
+    P4Helper p4SwitchHelper;
+    p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
+    p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(0));
+    p4SwitchHelper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0));
 
-  if (enableTracePcap) {
-    csma.EnablePcapAll("p4-basic-example");
-  }
+    P4Controller controller;
 
-  // Run simulation
-  NS_LOG_INFO("Running simulation...");
-  unsigned long simulate_start = getTickCount();
-  Simulator::Stop(Seconds(global_stop_time));
-  Simulator::Run();
-  Simulator::Destroy();
+    for (unsigned int i = 0; i < switchNum; i++)
+    {
+        std::string flowTablePath = flowTableDirPath + "flowtable_" + std::to_string(i) + ".txt";
+        p4SwitchHelper.SetDeviceAttribute("FlowTablePath", StringValue(flowTablePath));
+        NS_LOG_INFO("*** P4 switch configuration: " << p4JsonPath << ", \n " << flowTablePath);
 
-  unsigned long end = getTickCount();
-  NS_LOG_INFO("Simulate Running time: "
-              << end - simulate_start << "ms" << std::endl
-              << "Total Running time: " << end - start << "ms" << std::endl
-              << "Run successfully!");
+        NetDeviceContainer p4SwitchNetDeviceContainer =
+            p4SwitchHelper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
 
-  PrintFinalThroughput();
+        for (uint32_t j = 0; j < p4SwitchNetDeviceContainer.GetN(); j++)
+        {
+            Ptr<P4SwitchNetDevice> p4sw =
+                DynamicCast<P4SwitchNetDevice>(p4SwitchNetDeviceContainer.Get(j));
+            if (p4sw)
+            {
+                controller.RegisterSwitch(p4sw);
+                controller.ConnectToSwitchEvents(0); // connect early
 
-  return 0;
+                Simulator::Schedule(Seconds(2.0), [&controller]() {
+                    controller.PrintTableEntryCount(0, "MyIngress.ipv4_nhop");
+                });
+
+                Simulator::Schedule(Seconds(3.0), [&controller]() {
+                    controller.PrintFlowEntries(0, "MyIngress.ipv4_nhop");
+                });
+
+                Simulator::Schedule(Seconds(4.0), [&, p4sw]() {
+                    p4sw->EmitSwitchEvent(0, "Hello world from test event");
+                });
+            }
+            else
+            {
+                NS_LOG_WARN("Failed to cast device at index " << j << " to P4SwitchNetDevice");
+            }
+        }
+    }
+
+    // === Configuration for Link: h0 -----> h1 ===
+    unsigned int serverI = 3;
+    unsigned int clientI = 0;
+    uint16_t servPort = 9093; // UDP port for the server
+
+    // === Retrieve Server Address ===
+    Ptr<Node> node = terminals.Get(serverI);
+    Ptr<Ipv4> ipv4_adder = node->GetObject<Ipv4>();
+    Ipv4Address serverAddr1 = ipv4_adder->GetAddress(1, 0).GetLocal();
+    InetSocketAddress dst1 = InetSocketAddress(serverAddr1, servPort);
+
+    // === Setup Packet Sink on Server ===
+    PacketSinkHelper sink1("ns3::UdpSocketFactory", dst1);
+    ApplicationContainer sinkApp1 = sink1.Install(terminals.Get(serverI));
+    sinkApp1.Start(Seconds(sink_start_time));
+    sinkApp1.Stop(Seconds(sink_stop_time));
+
+    // === Setup OnOff Application on Client ===
+    OnOffHelper onOff1("ns3::UdpSocketFactory", dst1);
+    onOff1.SetAttribute("PacketSize", UintegerValue(pktSize));
+    onOff1.SetAttribute("DataRate", StringValue(appDataRate));
+    onOff1.SetAttribute("OnTime", StringValue("ns3::ConstantRandomVariable[Constant=1]"));
+    onOff1.SetAttribute("OffTime", StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+
+    ApplicationContainer app1 = onOff1.Install(terminals.Get(clientI));
+    app1.Start(Seconds(client_start_time));
+    app1.Stop(Seconds(client_stop_time));
+
+    // === Setup Tracing ===
+    Ptr<OnOffApplication> ptr_app1 =
+        DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
+    ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
+    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+
+    if (enableTracePcap)
+    {
+        csma.EnablePcapAll("p4-basic-controller");
+    }
+
+    // Run simulation
+    NS_LOG_INFO("Running simulation...");
+    unsigned long simulate_start = getTickCount();
+    Simulator::Stop(Seconds(global_stop_time));
+    Simulator::Run();
+    Simulator::Destroy();
+
+    unsigned long end = getTickCount();
+    NS_LOG_INFO("Simulate Running time: " << end - simulate_start << "ms" << std::endl
+                                          << "Total Running time: " << end - start << "ms"
+                                          << std::endl
+                                          << "Run successfully!");
+
+    PrintFinalThroughput();
+
+    return 0;
 }

--- a/examples/p4-basic-example.cc
+++ b/examples/p4-basic-example.cc
@@ -41,6 +41,7 @@
 #include "ns3/bridge-helper.h"
 #include "ns3/core-module.h"
 #include "ns3/csma-helper.h"
+#include "ns3/csma-net-device.h"
 #include "ns3/format-utils.h"
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
@@ -62,16 +63,22 @@ double client_stop_time = client_start_time + 3;
 double sink_stop_time = client_stop_time + 5;
 double global_stop_time = sink_stop_time + 5;
 
-bool first_tx = true;
-bool first_rx = true;
-int counter_sender_10 = 10;
-int counter_receiver_10 = 10;
 double first_packet_send_time_tx = 0.0;
 double last_packet_send_time_tx = 0.0;
 double first_packet_received_time_rx = 0.0;
 double last_packet_received_time_rx = 0.0;
 uint64_t totalTxBytes = 0;
 uint64_t totalRxBytes = 0;
+
+// MAC-layer stats (data packets only, ARP <= 64 bytes skipped)
+uint64_t macTxBytes = 0;
+uint64_t macRxBytes = 0;
+double firstMacTxTime = 0.0;
+double lastMacTxTime = 0.0;
+double firstMacRxTime = 0.0;
+double lastMacRxTime = 0.0;
+bool firstMacTx = true;
+bool firstMacRx = true;
 
 // Convert IP address to hexadecimal format
 std::string
@@ -104,44 +111,67 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-void
-TxCallback(Ptr<const Packet> packet)
+static void
+TxDropTrace(std::string label, Ptr<const Packet> p)
 {
-    if (first_tx)
+    NS_LOG_DEBUG(Simulator::Now().GetSeconds()
+                 << "s [" << label << "][DROP] size=" << p->GetSize());
+}
+
+static void
+MacTxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacTx] size=" << p->GetSize());
+    if (label == "TX-host" && p->GetSize() > 64)
     {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
-        first_packet_send_time_tx = Simulator::Now().GetSeconds();
-        counter_sender_10--;
-        if (counter_sender_10 == 0)
+        if (firstMacTx)
         {
-            first_tx = false;
+            firstMacTxTime = now;
+            firstMacTx = false;
         }
+        lastMacTxTime = now;
+        macTxBytes += p->GetSize();
     }
-    else
+}
+
+static void
+MacRxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacRx] size=" << p->GetSize());
+    if (label == "RX-host" && p->GetSize() > 64)
     {
-        totalTxBytes += packet->GetSize();
-        last_packet_send_time_tx = Simulator::Now().GetSeconds();
+        if (firstMacRx)
+        {
+            firstMacRxTime = now;
+            firstMacRx = false;
+        }
+        lastMacRxTime = now;
+        macRxBytes += p->GetSize();
     }
 }
 
 void
-RxCallback(Ptr<const Packet> packet, const Address& addr)
+TxCallback(uint32_t dataSize, Ptr<const Packet> packet)
 {
-    if (first_rx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_send_time_tx == 0.0)
+        first_packet_send_time_tx = Simulator::Now().GetSeconds();
+    totalTxBytes += packet->GetSize();
+    last_packet_send_time_tx = Simulator::Now().GetSeconds();
+}
+
+void
+RxCallback(uint32_t dataSize, Ptr<const Packet> packet, const Address& addr)
+{
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_received_time_rx == 0.0)
         first_packet_received_time_rx = Simulator::Now().GetSeconds();
-        counter_receiver_10--;
-        if (counter_receiver_10 == 0)
-        {
-            first_rx = false;
-        }
-    }
-    else
-    {
-        totalRxBytes += packet->GetSize();
-        last_packet_received_time_rx = Simulator::Now().GetSeconds();
-    }
+    totalRxBytes += packet->GetSize();
+    last_packet_received_time_rx = Simulator::Now().GetSeconds();
 }
 
 void
@@ -150,21 +180,35 @@ PrintFinalThroughput()
     double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
     double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
-    double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-    std::cout << "client_start_time: " << first_packet_send_time_tx
-              << "client_stop_time: " << last_packet_send_time_tx
-              << "sink_start_time: " << first_packet_received_time_rx
-              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+    double finalTxThroughput = (send_time > 0) ? (totalTxBytes * 8.0) / (send_time * 1e6) : 0.0;
+    double finalRxThroughput =
+        (elapsed_time > 0) ? (totalRxBytes * 8.0) / (elapsed_time * 1e6) : 0.0;
+    double pktDeliveryRatio =
+        (totalTxBytes > 0) ? (double)totalRxBytes / totalTxBytes * 100.0 : 0.0;
+
+    double macTxTime = lastMacTxTime - firstMacTxTime;
+    double macRxTime = lastMacRxTime - firstMacRxTime;
+    double macTxThroughput = (macTxTime > 0) ? (macTxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
+    double macRxThroughput = (macRxTime > 0) ? (macRxBytes * 8.0) / (macRxTime * 1e6) : 0.0;
 
     std::cout << "======================================" << std::endl;
     std::cout << "Final Simulation Results:" << std::endl;
-    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
+    std::cout << "  ** [App Layer]" << std::endl;
+    std::cout << "  PDR: " << pktDeliveryRatio << "%" << std::endl;
+    std::cout << "  TX: " << totalTxBytes << " bytes  (" << first_packet_send_time_tx << "s -> "
+              << last_packet_send_time_tx << "s,  elapsed=" << send_time << "s)" << std::endl;
+    std::cout << "  RX: " << totalRxBytes << " bytes  (" << first_packet_received_time_rx << "s -> "
+              << last_packet_received_time_rx << "s,  elapsed=" << elapsed_time << "s)"
               << std::endl;
-    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
-              << std::endl;
-    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
-    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "  TX Throughput: " << finalTxThroughput << " Mbps" << std::endl;
+    std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "  ** [MAC Layer]" << std::endl;
+    std::cout << "  TX-host MacTx: " << macTxBytes << " bytes  (" << firstMacTxTime << "s -> "
+              << lastMacTxTime << "s,  elapsed=" << macTxTime << "s)" << std::endl;
+    std::cout << "  RX-host MacRx: " << macRxBytes << " bytes  (" << firstMacRxTime << "s -> "
+              << lastMacRxTime << "s,  elapsed=" << macRxTime << "s)" << std::endl;
+    std::cout << "  MAC TX Throughput: " << macTxThroughput << " Mbps" << std::endl;
+    std::cout << "  MAC RX Throughput: " << macRxThroughput << " Mbps" << std::endl;
     std::cout << "======================================" << std::endl;
 }
 
@@ -404,8 +448,33 @@ main(int argc, char* argv[])
     // === Setup Tracing ===
     Ptr<OnOffApplication> ptr_app1 =
         DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
-    ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+    ptr_app1->TraceConnectWithoutContext("Tx", MakeBoundCallback(&TxCallback, (uint32_t)pktSize));
+    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx",
+                                                MakeBoundCallback(&RxCallback, (uint32_t)pktSize));
+
+    // Attach MAC-level traces to the sender NIC
+    Ptr<CsmaNetDevice> txDev = DynamicCast<CsmaNetDevice>(terminals.Get(clientI)->GetDevice(0));
+    if (txDev)
+    {
+        txDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("TX-host")));
+    }
+
+    // Attach MAC-level traces to the receiver NIC
+    Ptr<CsmaNetDevice> rxDev = DynamicCast<CsmaNetDevice>(terminals.Get(serverI)->GetDevice(0));
+    if (rxDev)
+    {
+        rxDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("RX-host")));
+    }
 
     if (enableTracePcap)
     {

--- a/examples/p4-basic-example.cc
+++ b/examples/p4-basic-example.cc
@@ -190,7 +190,6 @@ main(int argc, char* argv[])
     LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
 
     // ============================ parameters ============================
-    int running_number = 0;
     uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments, default 512
     std::string appDataRate = "3Mbps"; // Default application data rate
     std::string ns3_link_rate = "1000Mbps";
@@ -205,7 +204,6 @@ main(int argc, char* argv[])
 
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
     cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
     cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);

--- a/examples/p4-basic-tunnel.cc
+++ b/examples/p4-basic-tunnel.cc
@@ -182,8 +182,6 @@ main(int argc, char* argv[])
     Packet::EnablePrinting();
 
     // ============================ parameters ============================
-
-    int running_number = 0;
     uint16_t pktSize = 1000; // in Bytes. 1458 to prevent fragments, default 512
     std::string appDataRate[] = {"1Mbps", "4Mbps"}; // Default application data rate
     std::string ns3_link_rate = "100Mbps";
@@ -198,7 +196,6 @@ main(int argc, char* argv[])
 
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
     cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
     cmd.Parse(argc, argv);
@@ -442,7 +439,10 @@ main(int argc, char* argv[])
     app2.Stop(Seconds(client_stop_time));
 
     // Enable pcap tracing
-    p4p2phelper.EnablePcapAll("p4-basic-tunnel");
+    if (enableTracePcap)
+    {
+        p4p2phelper.EnablePcapAll("p4-basic-tunnel");
+    }
 
     // Run simulation
     NS_LOG_INFO("Running simulation...");

--- a/examples/p4-calc.cc
+++ b/examples/p4-calc.cc
@@ -30,7 +30,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE("p4-calc");
+NS_LOG_COMPONENT_DEFINE("P4Calculator");
 
 // Convert IP address to hexadecimal format
 std::string
@@ -139,7 +139,7 @@ struct HostNodeC_t
 int
 main(int argc, char* argv[])
 {
-    LogComponentEnable("p4-calc", LOG_LEVEL_INFO);
+    LogComponentEnable("P4Calculator", LOG_LEVEL_INFO);
     ns3::PacketMetadata::Enable(); // Enable packet metadata tracing support
 
     // simulation parameters

--- a/examples/p4-controller-action-profile.cc
+++ b/examples/p4-controller-action-profile.cc
@@ -53,7 +53,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE("P4BasicExample");
+NS_LOG_COMPONENT_DEFINE("P4ControllerActionProfile");
 
 unsigned long start = getTickCount();
 double global_start_time = 1.0;
@@ -75,377 +75,396 @@ uint64_t totalTxBytes = 0;
 uint64_t totalRxBytes = 0;
 
 // Convert IP address to hexadecimal format
-std::string ConvertIpToHex(Ipv4Address ipAddr) {
-  std::ostringstream hexStream;
-  uint32_t ip = ipAddr.Get(); // Get the IP address as a 32-bit integer
-  hexStream << "0x" << std::hex << std::setfill('0') << std::setw(2)
-            << ((ip >> 24) & 0xFF)                 // First byte
-            << std::setw(2) << ((ip >> 16) & 0xFF) // Second byte
-            << std::setw(2) << ((ip >> 8) & 0xFF)  // Third byte
-            << std::setw(2) << (ip & 0xFF);        // Fourth byte
-  return hexStream.str();
+std::string
+ConvertIpToHex(Ipv4Address ipAddr)
+{
+    std::ostringstream hexStream;
+    uint32_t ip = ipAddr.Get(); // Get the IP address as a 32-bit integer
+    hexStream << "0x" << std::hex << std::setfill('0') << std::setw(2)
+              << ((ip >> 24) & 0xFF)                 // First byte
+              << std::setw(2) << ((ip >> 16) & 0xFF) // Second byte
+              << std::setw(2) << ((ip >> 8) & 0xFF)  // Third byte
+              << std::setw(2) << (ip & 0xFF);        // Fourth byte
+    return hexStream.str();
 }
 
 // Convert MAC address to hexadecimal format
-std::string ConvertMacToHex(Address macAddr) {
-  std::ostringstream hexStream;
-  Mac48Address mac =
-      Mac48Address::ConvertFrom(macAddr); // Convert Address to Mac48Address
-  uint8_t buffer[6];
-  mac.CopyTo(buffer); // Copy MAC address bytes into buffer
+std::string
+ConvertMacToHex(Address macAddr)
+{
+    std::ostringstream hexStream;
+    Mac48Address mac = Mac48Address::ConvertFrom(macAddr); // Convert Address to Mac48Address
+    uint8_t buffer[6];
+    mac.CopyTo(buffer); // Copy MAC address bytes into buffer
 
-  hexStream << "0x";
-  for (int i = 0; i < 6; ++i) {
-    hexStream << std::hex << std::setfill('0') << std::setw(2)
-              << static_cast<int>(buffer[i]);
-  }
-  return hexStream.str();
-}
-
-void TxCallback(Ptr<const Packet> packet) {
-  if (first_tx) {
-    // here we just simple jump the first 10 pkts (include some of ARP packets)
-    first_packet_send_time_tx = Simulator::Now().GetSeconds();
-    counter_sender_10--;
-    if (counter_sender_10 == 0) {
-      first_tx = false;
+    hexStream << "0x";
+    for (int i = 0; i < 6; ++i)
+    {
+        hexStream << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(buffer[i]);
     }
-  } else {
-    totalTxBytes += packet->GetSize();
-    last_packet_send_time_tx = Simulator::Now().GetSeconds();
-  }
+    return hexStream.str();
 }
 
-void RxCallback(Ptr<const Packet> packet, const Address &addr) {
-  if (first_rx) {
-    // here we just simple jump the first 10 pkts (include some of ARP packets)
-    first_packet_received_time_rx = Simulator::Now().GetSeconds();
-    counter_receiver_10--;
-    if (counter_receiver_10 == 0) {
-      first_rx = false;
+void
+TxCallback(Ptr<const Packet> packet)
+{
+    if (first_tx)
+    {
+        // here we just simple jump the first 10 pkts (include some of ARP packets)
+        first_packet_send_time_tx = Simulator::Now().GetSeconds();
+        counter_sender_10--;
+        if (counter_sender_10 == 0)
+        {
+            first_tx = false;
+        }
     }
-  } else {
-    totalRxBytes += packet->GetSize();
-    last_packet_received_time_rx = Simulator::Now().GetSeconds();
-  }
+    else
+    {
+        totalTxBytes += packet->GetSize();
+        last_packet_send_time_tx = Simulator::Now().GetSeconds();
+    }
 }
 
-void PrintFinalThroughput() {
-  double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
-  double elapsed_time =
-      last_packet_received_time_rx - first_packet_received_time_rx;
+void
+RxCallback(Ptr<const Packet> packet, const Address& addr)
+{
+    if (first_rx)
+    {
+        // here we just simple jump the first 10 pkts (include some of ARP packets)
+        first_packet_received_time_rx = Simulator::Now().GetSeconds();
+        counter_receiver_10--;
+        if (counter_receiver_10 == 0)
+        {
+            first_rx = false;
+        }
+    }
+    else
+    {
+        totalRxBytes += packet->GetSize();
+        last_packet_received_time_rx = Simulator::Now().GetSeconds();
+    }
+}
 
-  double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-  double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-  std::cout << "client_start_time: " << first_packet_send_time_tx
-            << "client_stop_time: " << last_packet_send_time_tx
-            << "sink_start_time: " << first_packet_received_time_rx
-            << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+void
+PrintFinalThroughput()
+{
+    double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
+    double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
-  std::cout << "======================================" << std::endl;
-  std::cout << "Final Simulation Results:" << std::endl;
-  std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time "
-            << send_time << std::endl;
-  std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time "
-            << elapsed_time << std::endl;
-  std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps"
-            << std::endl;
-  std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps"
-            << std::endl;
-  std::cout << "======================================" << std::endl;
+    double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
+    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
+    std::cout << "client_start_time: " << first_packet_send_time_tx
+              << "client_stop_time: " << last_packet_send_time_tx
+              << "sink_start_time: " << first_packet_received_time_rx
+              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+
+    std::cout << "======================================" << std::endl;
+    std::cout << "Final Simulation Results:" << std::endl;
+    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
+              << std::endl;
+    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
+              << std::endl;
+    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
+    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "======================================" << std::endl;
 }
 
 // ============================ data struct ============================
-struct SwitchNodeC_t {
-  NetDeviceContainer switchDevices;
-  std::vector<std::string> switchPortInfos;
+struct SwitchNodeC_t
+{
+    NetDeviceContainer switchDevices;
+    std::vector<std::string> switchPortInfos;
 };
 
-struct HostNodeC_t {
-  NetDeviceContainer hostDevice;
-  Ipv4InterfaceContainer hostIpv4;
-  unsigned int linkSwitchIndex;
-  unsigned int linkSwitchPort;
-  std::string hostIpv4Str;
+struct HostNodeC_t
+{
+    NetDeviceContainer hostDevice;
+    Ipv4InterfaceContainer hostIpv4;
+    unsigned int linkSwitchIndex;
+    unsigned int linkSwitchPort;
+    std::string hostIpv4Str;
 };
 
-int main(int argc, char *argv[]) {
-  LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
-  LogComponentEnable("P4Controller", LOG_LEVEL_INFO);
+int
+main(int argc, char* argv[])
+{
+    LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
+    LogComponentEnable("P4Controller", LOG_LEVEL_INFO);
 
-  // ============================ parameters ============================
-  int running_number = 0;
-  uint16_t pktSize = 1000; // in Bytes. 1458 to prevent fragments, default 512
-  std::string appDataRate = "3Mbps"; // Default application data rate
-  std::string ns3_link_rate = "1000Mbps";
-  bool enableTracePcap = true;
+    // ============================ parameters ============================
+    uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments, default 512
+    std::string appDataRate = "3Mbps"; // Default application data rate
+    std::string ns3_link_rate = "1000Mbps";
+    bool enableTracePcap = true;
 
-  // Use P4SIM_DIR environment variable for portable paths
-  std::string p4SrcDir = GetP4ExamplePath() + "/action_profile";
-  std::string p4JsonPath = p4SrcDir + "/action-profile.json";
-  std::string flowTableDirPath = p4SrcDir + "/";
-  std::string topoInput = p4SrcDir + "/topo.txt";
-  std::string topoFormat("CsmaTopo");
+    // Use P4SIM_DIR environment variable for portable paths
+    std::string p4SrcDir = GetP4ExamplePath() + "/action_profile";
+    std::string p4JsonPath = p4SrcDir + "/action-profile.json";
+    std::string flowTableDirPath = p4SrcDir + "/";
+    std::string topoInput = p4SrcDir + "/topo.txt";
+    std::string topoFormat("CsmaTopo");
 
-  // ============================  command line ============================
-  CommandLine cmd;
-  cmd.AddValue("runnum", "running number in loops", running_number);
-  cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
-  cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)",
-               appDataRate);
-  cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]",
-               enableTracePcap);
-  cmd.Parse(argc, argv);
+    // ============================  command line ============================
+    CommandLine cmd;
+    cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
+    cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
+    cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
+    cmd.Parse(argc, argv);
 
-  // ============================ topo -> network ============================
-  P4TopologyReaderHelper p4TopoHelper;
-  p4TopoHelper.SetFileName(topoInput);
-  p4TopoHelper.SetFileType(topoFormat);
-  NS_LOG_INFO("*** Reading topology from file: "
-              << topoInput << " with format: " << topoFormat);
+    // ============================ topo -> network ============================
+    P4TopologyReaderHelper p4TopoHelper;
+    p4TopoHelper.SetFileName(topoInput);
+    p4TopoHelper.SetFileType(topoFormat);
+    NS_LOG_INFO("*** Reading topology from file: " << topoInput << " with format: " << topoFormat);
 
-  // Get the topology reader, and read the file, load in the m_linksList.
-  Ptr<P4TopologyReader> topoReader = p4TopoHelper.GetTopologyReader();
+    // Get the topology reader, and read the file, load in the m_linksList.
+    Ptr<P4TopologyReader> topoReader = p4TopoHelper.GetTopologyReader();
 
-  topoReader->PrintTopology();
+    topoReader->PrintTopology();
 
-  if (topoReader->LinksSize() == 0) {
-    NS_LOG_ERROR("Problems reading the topology file. Failing.");
-    return -1;
-  }
+    if (topoReader->LinksSize() == 0)
+    {
+        NS_LOG_ERROR("Problems reading the topology file. Failing.");
+        return -1;
+    }
 
-  // get switch and host node
-  NodeContainer terminals = topoReader->GetHostNodeContainer();
-  NodeContainer switchNode = topoReader->GetSwitchNodeContainer();
+    // get switch and host node
+    NodeContainer terminals = topoReader->GetHostNodeContainer();
+    NodeContainer switchNode = topoReader->GetSwitchNodeContainer();
 
-  const unsigned int hostNum = terminals.GetN();
-  const unsigned int switchNum = switchNode.GetN();
-  NS_LOG_INFO("*** Host number: " << hostNum
-                                  << ", Switch number: " << switchNum);
+    const unsigned int hostNum = terminals.GetN();
+    const unsigned int switchNum = switchNode.GetN();
+    NS_LOG_INFO("*** Host number: " << hostNum << ", Switch number: " << switchNum);
 
-  // set default network link parameter
-  CsmaHelper csma;
-  csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
-  csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
+    // set default network link parameter
+    CsmaHelper csma;
+    csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
+    csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-  // NetDeviceContainer hostDevices;
-  // NetDeviceContainer switchDevices;
-  P4TopologyReader::ConstLinksIterator_t iter;
-  SwitchNodeC_t switchNodes[switchNum];
-  HostNodeC_t hostNodes[hostNum];
-  unsigned int fromIndex, toIndex;
-  std::string dataRate, delay;
-  for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd();
-       iter++) {
-    if (iter->GetAttributeFailSafe("DataRate", dataRate))
-      csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-    if (iter->GetAttributeFailSafe("Delay", delay))
-      csma.SetChannelAttribute("Delay", StringValue(delay));
+    // NetDeviceContainer hostDevices;
+    // NetDeviceContainer switchDevices;
+    P4TopologyReader::ConstLinksIterator_t iter;
+    SwitchNodeC_t switchNodes[switchNum];
+    HostNodeC_t hostNodes[hostNum];
+    unsigned int fromIndex, toIndex;
+    std::string dataRate, delay;
+    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
+    {
+        if (iter->GetAttributeFailSafe("DataRate", dataRate))
+            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
+        if (iter->GetAttributeFailSafe("Delay", delay))
+            csma.SetChannelAttribute("Delay", StringValue(delay));
 
-    fromIndex = iter->GetFromIndex();
-    toIndex = iter->GetToIndex();
-    NetDeviceContainer link =
-        csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
+        fromIndex = iter->GetFromIndex();
+        toIndex = iter->GetToIndex();
+        NetDeviceContainer link =
+            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
 
-    if (iter->GetFromType() == 's' && iter->GetToType() == 's') {
-      NS_LOG_INFO("*** Link from  switch "
-                  << fromIndex << " to  switch " << toIndex
-                  << " with data rate " << dataRate << " and delay " << delay);
+        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
+        {
+            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
+                                                 << " with data rate " << dataRate << " and delay "
+                                                 << delay);
 
-      unsigned int fromSwitchPortNumber =
-          switchNodes[fromIndex].switchDevices.GetN();
-      unsigned int toSwitchPortNumber =
-          switchNodes[toIndex].switchDevices.GetN();
-      switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-      switchNodes[fromIndex].switchPortInfos.push_back(
-          "s" + UintToString(toIndex) + "_" + UintToString(toSwitchPortNumber));
+            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
+            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
+            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
+                                                             UintToString(toSwitchPortNumber));
 
-      switchNodes[toIndex].switchDevices.Add(link.Get(1));
-      switchNodes[toIndex].switchPortInfos.push_back(
-          "s" + UintToString(fromIndex) + "_" +
-          UintToString(fromSwitchPortNumber));
-    } else {
-      if (iter->GetFromType() == 's' && iter->GetToType() == 'h') {
-        NS_LOG_INFO("*** Link from switch "
-                    << fromIndex << " to  host" << toIndex << " with data rate "
-                    << dataRate << " and delay " << delay);
-
-        unsigned int fromSwitchPortNumber =
-            switchNodes[fromIndex].switchDevices.GetN();
-        switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-        switchNodes[fromIndex].switchPortInfos.push_back(
-            "h" + UintToString(toIndex - switchNum));
-
-        hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-        hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-        hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-      } else {
-        if (iter->GetFromType() == 'h' && iter->GetToType() == 's') {
-          NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch"
-                                            << toIndex << " with data rate "
-                                            << dataRate << " and delay "
-                                            << delay);
-          unsigned int toSwitchPortNumber =
-              switchNodes[toIndex].switchDevices.GetN();
-          switchNodes[toIndex].switchDevices.Add(link.Get(1));
-          switchNodes[toIndex].switchPortInfos.push_back(
-              "h" + UintToString(fromIndex - switchNum));
-
-          hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-          hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-          hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-        } else {
-          NS_LOG_ERROR("link error!");
-          abort();
+            switchNodes[toIndex].switchDevices.Add(link.Get(1));
+            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
+                                                           UintToString(fromSwitchPortNumber));
         }
-      }
+        else
+        {
+            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
+            {
+                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
+                                                    << " with data rate " << dataRate
+                                                    << " and delay " << delay);
+
+                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
+                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+                switchNodes[fromIndex].switchPortInfos.push_back("h" +
+                                                                 UintToString(toIndex - switchNum));
+
+                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
+                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
+                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
+            }
+            else
+            {
+                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
+                {
+                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
+                                                      << " with data rate " << dataRate
+                                                      << " and delay " << delay);
+                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
+                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
+                    switchNodes[toIndex].switchPortInfos.push_back(
+                        "h" + UintToString(fromIndex - switchNum));
+
+                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
+                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
+                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
+                }
+                else
+                {
+                    NS_LOG_ERROR("link error!");
+                    abort();
+                }
+            }
+        }
     }
-  }
 
-  // ========================Print the Channel Type and NetDevice
-  // Type========================
+    // ========================Print the Channel Type and NetDevice
+    // Type========================
 
-  InternetStackHelper internet;
-  internet.Install(terminals);
-  internet.Install(switchNode);
+    InternetStackHelper internet;
+    internet.Install(terminals);
+    internet.Install(switchNode);
 
-  Ipv4AddressHelper ipv4;
-  ipv4.SetBase("10.1.1.0", "255.255.255.0");
-  std::vector<Ipv4InterfaceContainer> terminalInterfaces(hostNum);
-  std::vector<std::string> hostIpv4(hostNum);
+    Ipv4AddressHelper ipv4;
+    ipv4.SetBase("10.1.1.0", "255.255.255.0");
+    std::vector<Ipv4InterfaceContainer> terminalInterfaces(hostNum);
+    std::vector<std::string> hostIpv4(hostNum);
 
-  for (unsigned int i = 0; i < hostNum; i++) {
-    terminalInterfaces[i] = ipv4.Assign(terminals.Get(i)->GetDevice(0));
-    hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
-  }
-
-  //===============================  Print IP and MAC
-  //addresses===============================
-  NS_LOG_INFO("Node IP and MAC addresses:");
-  for (uint32_t i = 0; i < terminals.GetN(); ++i) {
-    Ptr<Node> node = terminals.Get(i);
-    Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-    Ptr<NetDevice> netDevice = node->GetDevice(0);
-
-    // Get the IP address
-    Ipv4Address ipAddr =
-        ipv4->GetAddress(1, 0).GetLocal(); // Interface index 1 corresponds to
-                                           // the first assigned IP
-
-    // Get the MAC address
-    Ptr<NetDevice> device =
-        node->GetDevice(0); // Assuming the first device is the desired one
-    Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
-
-    NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
-
-    // Convert to hexadecimal
-    std::string ipHex = ConvertIpToHex(ipAddr);
-    std::string macHex = ConvertMacToHex(mac);
-    NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
-  }
-
-  // Bridge or P4 switch configuration
-  P4Helper p4SwitchHelper;
-  p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
-  p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(0));
-  p4SwitchHelper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0));
-
-  P4Controller controller;
-
-  for (unsigned int i = 0; i < switchNum; i++) {
-    std::string flowTablePath =
-        flowTableDirPath + "flowtable_" + std::to_string(i) + ".txt";
-    p4SwitchHelper.SetDeviceAttribute("FlowTablePath",
-                                      StringValue(flowTablePath));
-    NS_LOG_INFO("*** P4 switch configuration: " << p4JsonPath << ", \n "
-                                                << flowTablePath);
-
-    NetDeviceContainer p4SwitchNetDeviceContainer =
-        p4SwitchHelper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
-
-    for (uint32_t j = 0; j < p4SwitchNetDeviceContainer.GetN(); j++) {
-      Ptr<P4SwitchNetDevice> p4sw =
-          DynamicCast<P4SwitchNetDevice>(p4SwitchNetDeviceContainer.Get(j));
-      if (p4sw) {
-        controller.RegisterSwitch(p4sw);
-
-        Simulator::Schedule(Seconds(1), [j, &controller]() {
-          uint32_t index = j;
-          std::string profile = "action_profile_0";
-          std::string action = "cIngress.foo1";
-
-          bm::ActionData actionData;
-          bm::Data dstAddr(4);     // 4 bytes = 32 bits
-          dstAddr.set(0x0a0a0a0a); // Example IP: 10.10.10.10
-          actionData.push_back_action_data(dstAddr);
-          controller.GetActionProfileMembers(j, profile);
-          bm::ActionProfile::mbr_hdl_t member = 0;
-          controller.AddActionProfileMember(index, profile, action,
-                                            std::move(actionData), member);
-          controller.GetActionProfileMembers(j, profile);
-        });
-      } else {
-        NS_LOG_WARN("Failed to cast device at index "
-                    << j << " to P4SwitchNetDevice");
-      }
+    for (unsigned int i = 0; i < hostNum; i++)
+    {
+        terminalInterfaces[i] = ipv4.Assign(terminals.Get(i)->GetDevice(0));
+        hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
     }
-  }
 
-  // === Configuration for Link: h0 -----> h1 ===
-  unsigned int serverI = 3;
-  unsigned int clientI = 0;
-  uint16_t servPort = 9093; // UDP port for the server
+    //===============================  Print IP and MAC
+    // addresses===============================
+    NS_LOG_INFO("Node IP and MAC addresses:");
+    for (uint32_t i = 0; i < terminals.GetN(); ++i)
+    {
+        Ptr<Node> node = terminals.Get(i);
+        Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
+        Ptr<NetDevice> netDevice = node->GetDevice(0);
 
-  // === Retrieve Server Address ===
-  Ptr<Node> node = terminals.Get(serverI);
-  Ptr<Ipv4> ipv4_adder = node->GetObject<Ipv4>();
-  Ipv4Address serverAddr1 = ipv4_adder->GetAddress(1, 0).GetLocal();
-  InetSocketAddress dst1 = InetSocketAddress(serverAddr1, servPort);
+        // Get the IP address
+        Ipv4Address ipAddr = ipv4->GetAddress(1, 0).GetLocal(); // Interface index 1 corresponds to
+                                                                // the first assigned IP
 
-  // === Setup Packet Sink on Server ===
-  PacketSinkHelper sink1("ns3::UdpSocketFactory", dst1);
-  ApplicationContainer sinkApp1 = sink1.Install(terminals.Get(serverI));
-  sinkApp1.Start(Seconds(sink_start_time));
-  sinkApp1.Stop(Seconds(sink_stop_time));
+        // Get the MAC address
+        Ptr<NetDevice> device = node->GetDevice(0); // Assuming the first device is the desired one
+        Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
 
-  // === Setup OnOff Application on Client ===
-  OnOffHelper onOff1("ns3::UdpSocketFactory", dst1);
-  onOff1.SetAttribute("PacketSize", UintegerValue(pktSize));
-  onOff1.SetAttribute("DataRate", StringValue(appDataRate));
-  onOff1.SetAttribute("OnTime",
-                      StringValue("ns3::ConstantRandomVariable[Constant=1]"));
-  onOff1.SetAttribute("OffTime",
-                      StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
 
-  ApplicationContainer app1 = onOff1.Install(terminals.Get(clientI));
-  app1.Start(Seconds(client_start_time));
-  app1.Stop(Seconds(client_stop_time));
+        // Convert to hexadecimal
+        std::string ipHex = ConvertIpToHex(ipAddr);
+        std::string macHex = ConvertMacToHex(mac);
+        NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
+    }
 
-  // === Setup Tracing ===
-  Ptr<OnOffApplication> ptr_app1 =
-      DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
-  ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-  sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+    // Bridge or P4 switch configuration
+    P4Helper p4SwitchHelper;
+    p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
+    p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(0));
+    p4SwitchHelper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0));
 
-  if (enableTracePcap) {
-    csma.EnablePcapAll("p4-basic-example");
-  }
+    P4Controller controller;
 
-  // Run simulation
-  NS_LOG_INFO("Running simulation...");
-  unsigned long simulate_start = getTickCount();
-  Simulator::Stop(Seconds(global_stop_time));
-  Simulator::Run();
-  Simulator::Destroy();
+    for (unsigned int i = 0; i < switchNum; i++)
+    {
+        std::string flowTablePath = flowTableDirPath + "flowtable_" + std::to_string(i) + ".txt";
+        p4SwitchHelper.SetDeviceAttribute("FlowTablePath", StringValue(flowTablePath));
+        NS_LOG_INFO("*** P4 switch configuration: " << p4JsonPath << ", \n " << flowTablePath);
 
-  unsigned long end = getTickCount();
-  NS_LOG_INFO("Simulate Running time: "
-              << end - simulate_start << "ms" << std::endl
-              << "Total Running time: " << end - start << "ms" << std::endl
-              << "Run successfully!");
+        NetDeviceContainer p4SwitchNetDeviceContainer =
+            p4SwitchHelper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
 
-  PrintFinalThroughput();
+        for (uint32_t j = 0; j < p4SwitchNetDeviceContainer.GetN(); j++)
+        {
+            Ptr<P4SwitchNetDevice> p4sw =
+                DynamicCast<P4SwitchNetDevice>(p4SwitchNetDeviceContainer.Get(j));
+            if (p4sw)
+            {
+                controller.RegisterSwitch(p4sw);
 
-  return 0;
+                Simulator::Schedule(Seconds(1), [j, &controller]() {
+                    uint32_t index = j;
+                    std::string profile = "action_profile_0";
+                    std::string action = "cIngress.foo1";
+
+                    bm::ActionData actionData;
+                    bm::Data dstAddr(4);     // 4 bytes = 32 bits
+                    dstAddr.set(0x0a0a0a0a); // Example IP: 10.10.10.10
+                    actionData.push_back_action_data(dstAddr);
+                    controller.GetActionProfileMembers(j, profile);
+                    bm::ActionProfile::mbr_hdl_t member = 0;
+                    controller.AddActionProfileMember(index,
+                                                      profile,
+                                                      action,
+                                                      std::move(actionData),
+                                                      member);
+                    controller.GetActionProfileMembers(j, profile);
+                });
+            }
+            else
+            {
+                NS_LOG_WARN("Failed to cast device at index " << j << " to P4SwitchNetDevice");
+            }
+        }
+    }
+
+    // === Configuration for Link: h0 -----> h1 ===
+    unsigned int serverI = 3;
+    unsigned int clientI = 0;
+    uint16_t servPort = 9093; // UDP port for the server
+
+    // === Retrieve Server Address ===
+    Ptr<Node> node = terminals.Get(serverI);
+    Ptr<Ipv4> ipv4_adder = node->GetObject<Ipv4>();
+    Ipv4Address serverAddr1 = ipv4_adder->GetAddress(1, 0).GetLocal();
+    InetSocketAddress dst1 = InetSocketAddress(serverAddr1, servPort);
+
+    // === Setup Packet Sink on Server ===
+    PacketSinkHelper sink1("ns3::UdpSocketFactory", dst1);
+    ApplicationContainer sinkApp1 = sink1.Install(terminals.Get(serverI));
+    sinkApp1.Start(Seconds(sink_start_time));
+    sinkApp1.Stop(Seconds(sink_stop_time));
+
+    // === Setup OnOff Application on Client ===
+    OnOffHelper onOff1("ns3::UdpSocketFactory", dst1);
+    onOff1.SetAttribute("PacketSize", UintegerValue(pktSize));
+    onOff1.SetAttribute("DataRate", StringValue(appDataRate));
+    onOff1.SetAttribute("OnTime", StringValue("ns3::ConstantRandomVariable[Constant=1]"));
+    onOff1.SetAttribute("OffTime", StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+
+    ApplicationContainer app1 = onOff1.Install(terminals.Get(clientI));
+    app1.Start(Seconds(client_start_time));
+    app1.Stop(Seconds(client_stop_time));
+
+    // === Setup Tracing ===
+    Ptr<OnOffApplication> ptr_app1 =
+        DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
+    ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
+    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+
+    if (enableTracePcap)
+    {
+        csma.EnablePcapAll("p4-controller-action-profile");
+    }
+
+    // Run simulation
+    NS_LOG_INFO("Running simulation...");
+    unsigned long simulate_start = getTickCount();
+    Simulator::Stop(Seconds(global_stop_time));
+    Simulator::Run();
+    Simulator::Destroy();
+
+    unsigned long end = getTickCount();
+    NS_LOG_INFO("Simulate Running time: " << end - simulate_start << "ms" << std::endl
+                                          << "Total Running time: " << end - start << "ms"
+                                          << std::endl
+                                          << "Run successfully!");
+
+    PrintFinalThroughput();
+
+    return 0;
 }

--- a/examples/p4-firewall.cc
+++ b/examples/p4-firewall.cc
@@ -53,7 +53,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE("P4BasicExample");
+NS_LOG_COMPONENT_DEFINE("P4Firewall");
 
 unsigned long start = getTickCount();
 double global_start_time = 1.0;
@@ -124,7 +124,7 @@ struct HostNodeC_t
 int
 main(int argc, char* argv[])
 {
-    LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
+    LogComponentEnable("P4Firewall", LOG_LEVEL_INFO);
 
     // ============================ parameters ============================
     uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments, default 512

--- a/examples/p4-link-monitoring.cc
+++ b/examples/p4-link-monitoring.cc
@@ -95,12 +95,10 @@ main(int argc, char* argv[])
     LogComponentEnable("P4LinkMonitoring", LOG_LEVEL_INFO);
 
     // ============================ parameters ============================
-
-    int running_number = 0;
     uint16_t pktSize = 512;              // in Bytes. 1458 to prevent fragments, default 512
     std::string appDataRate = "4096bps"; // Default application data rate
     std::string ns3_link_rate = "1000Mbps";
-    bool enableTracePcap = true;
+    bool enableTracePcap = false;
 
     // Use P4SIM_DIR environment variable for portable paths
     std::string p4SrcDir = GetP4ExamplePath() + "/link_monitor";
@@ -111,7 +109,6 @@ main(int argc, char* argv[])
 
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
     cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
     cmd.Parse(argc, argv);
@@ -344,7 +341,10 @@ main(int argc, char* argv[])
     app1.Stop(Seconds(30));
 
     // Enable pcap tracing
-    p4p2phelper.EnablePcapAll("p4-link-monitoring");
+    if (enableTracePcap)
+    {
+        p4p2phelper.EnablePcapAll("p4-link-monitoring");
+    }
 
     // Run simulation
     NS_LOG_INFO("Running simulation...");

--- a/examples/p4-pna-ipv4-forwarding.cc
+++ b/examples/p4-pna-ipv4-forwarding.cc
@@ -225,7 +225,6 @@ main(int argc, char* argv[])
     LogComponentEnable("P4PnaIpv4Forwarding", LOG_LEVEL_INFO);
 
     // ---- tuneable parameters ----
-    int runNum = 0;
     int model = 0;           // 0 = P4 PNA switch, 1 = ns-3 BridgeHelper
     uint16_t pktSize = 1000; // bytes per UDP payload
     uint32_t clientIndex = 0;
@@ -251,7 +250,6 @@ main(int argc, char* argv[])
 
     // ---- command line ----
     CommandLine cmd;
-    cmd.AddValue("runnum", "Run index used in loop experiments", runNum);
     cmd.AddValue("model", "0 = P4 PNA switch,  1 = ns-3 BridgeHelper", model);
     cmd.AddValue("pktSize", "UDP payload size in bytes", pktSize);
     cmd.AddValue("appDataRate", "OnOff application data rate", appDataRate);

--- a/examples/p4-psa-ipv4-forwarding.cc
+++ b/examples/p4-psa-ipv4-forwarding.cc
@@ -31,6 +31,7 @@
 #include "ns3/bridge-helper.h"
 #include "ns3/core-module.h"
 #include "ns3/csma-helper.h"
+#include "ns3/csma-net-device.h"
 #include "ns3/format-utils.h"
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
@@ -63,6 +64,16 @@ double last_packet_received_time_rx = 0.0;
 uint64_t totalTxBytes = 0;
 uint64_t totalRxBytes = 0;
 
+// MAC-layer stats (data packets only, ARP <= 64 bytes skipped)
+uint64_t macTxBytes = 0;
+uint64_t macRxBytes = 0;
+double firstMacTxTime = 0.0;
+double lastMacTxTime = 0.0;
+double firstMacRxTime = 0.0;
+double lastMacRxTime = 0.0;
+bool firstMacTx = true;
+bool firstMacRx = true;
+
 // Convert IP address to hexadecimal format
 std::string
 ConvertIpToHex(Ipv4Address ipAddr)
@@ -94,44 +105,72 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-void
-TxCallback(Ptr<const Packet> packet)
+static void
+TxDropTrace(std::string label, Ptr<const Packet> p)
 {
-    if (first_tx)
+    NS_LOG_DEBUG(Simulator::Now().GetSeconds()
+                 << "s [" << label << "][DROP] size=" << p->GetSize());
+}
+
+static void
+MacTxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacTx] size=" << p->GetSize());
+    if (label == "TX-host" && p->GetSize() > 64)
     {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
-        first_packet_send_time_tx = Simulator::Now().GetSeconds();
-        counter_sender_10--;
-        if (counter_sender_10 == 0)
+        if (firstMacTx)
         {
-            first_tx = false;
+            firstMacTxTime = now;
+            firstMacTx = false;
         }
+        lastMacTxTime = now;
+        macTxBytes += p->GetSize();
     }
-    else
+}
+
+static void
+MacRxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacRx] size=" << p->GetSize());
+    if (label == "RX-host" && p->GetSize() > 64)
     {
-        totalTxBytes += packet->GetSize();
-        last_packet_send_time_tx = Simulator::Now().GetSeconds();
+        if (firstMacRx)
+        {
+            firstMacRxTime = now;
+            firstMacRx = false;
+        }
+        lastMacRxTime = now;
+        macRxBytes += p->GetSize();
     }
 }
 
 void
-RxCallback(Ptr<const Packet> packet, const Address& addr)
+TxCallback(uint32_t dataSize, Ptr<const Packet> packet)
 {
-    if (first_rx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
+    // Here we filter out non-data packets (e.g., ARP) by checking the packet size against the
+    // expected data size. The system will first send ARP packets to resolve the MAC address, which
+    // are typically smaller than the application data packets. By only counting packets that match
+    // the expected data size, we can focus our throughput calculations on the actual application
+    // data being sent, providing a more accurate measure of the effective throughput of the system.
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_send_time_tx == 0.0)
+        first_packet_send_time_tx = Simulator::Now().GetSeconds();
+    totalTxBytes += packet->GetSize();
+    last_packet_send_time_tx = Simulator::Now().GetSeconds();
+}
+
+void
+RxCallback(uint32_t dataSize, Ptr<const Packet> packet, const Address& addr)
+{
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_received_time_rx == 0.0)
         first_packet_received_time_rx = Simulator::Now().GetSeconds();
-        counter_receiver_10--;
-        if (counter_receiver_10 == 0)
-        {
-            first_rx = false;
-        }
-    }
-    else
-    {
-        totalRxBytes += packet->GetSize();
-        last_packet_received_time_rx = Simulator::Now().GetSeconds();
-    }
+    totalRxBytes += packet->GetSize();
+    last_packet_received_time_rx = Simulator::Now().GetSeconds();
 }
 
 void
@@ -140,21 +179,35 @@ PrintFinalThroughput()
     double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
     double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
+    // Both TX and RX throughput use send_time as denominator:
+    // RX elapsed_time can be shorter than send_time when the last sent packet
+    // is still in flight (pipeline effect), which would inflate RX throughput.
+    // Using send_time gives a fair apples-to-apples comparison.
     double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-    std::cout << "client_start_time: " << first_packet_send_time_tx
-              << "client_stop_time: " << last_packet_send_time_tx
-              << "sink_start_time: " << first_packet_received_time_rx
-              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+    double finalRxThroughput = (totalRxBytes * 8.0) / (send_time * 1e6);
+    double pktDeliveryRatio =
+        (totalTxBytes > 0) ? (double)totalRxBytes / totalTxBytes * 100.0 : 0.0;
+
+    double macTxTime = lastMacTxTime - firstMacTxTime;
+    // double macRxTime = lastMacRxTime - firstMacRxTime;
+    double macTxThroughput = (macTxTime > 0) ? (macTxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
+    double macRxThroughput = (macTxTime > 0) ? (macRxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
 
     std::cout << "======================================" << std::endl;
     std::cout << "Final Simulation Results:" << std::endl;
-    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
-              << std::endl;
-    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
-              << std::endl;
-    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
-    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "  ** [App Layer]  (window = send_time = " << send_time << "s)" << std::endl;
+    std::cout << "  TX: " << totalTxBytes << " bytes  |  RX: " << totalRxBytes
+              << " bytes  |  PDR: " << pktDeliveryRatio << "%" << std::endl;
+    std::cout << "  TX Throughput: " << finalTxThroughput << " Mbps" << std::endl;
+    std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps  "
+              << "(RX elapsed=" << elapsed_time << "s)" << std::endl;
+    std::cout << "  ** [MAC Layer]  (window = macTxTime = " << macTxTime << "s)" << std::endl;
+    std::cout << "  TX-host MacTx: " << macTxBytes << " bytes" << "  (" << firstMacTxTime << "s -> "
+              << lastMacTxTime << "s)" << std::endl;
+    std::cout << "  RX-host MacRx: " << macRxBytes << " bytes" << "  (" << firstMacRxTime << "s -> "
+              << lastMacRxTime << "s)" << std::endl;
+    std::cout << "  MAC TX Throughput: " << macTxThroughput << " Mbps" << std::endl;
+    std::cout << "  MAC RX Throughput: " << macRxThroughput << " Mbps" << std::endl;
     std::cout << "======================================" << std::endl;
 }
 
@@ -234,7 +287,7 @@ main(int argc, char* argv[])
     // set default network link parameter
     CsmaHelper csma;
     csma.SetChannelAttribute("DataRate", StringValue(linkRate));
-    csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
+    csma.SetChannelAttribute("Delay", StringValue(linkDelay));
 
     NetDeviceContainer hostDevices;
     NetDeviceContainer switchDevices;
@@ -363,8 +416,32 @@ main(int argc, char* argv[])
     // === Setup Tracing ===
     Ptr<OnOffApplication> ptr_app1 =
         DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
-    ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+    ptr_app1->TraceConnectWithoutContext("Tx", MakeBoundCallback(&TxCallback, pktSize));
+    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeBoundCallback(&RxCallback, pktSize));
+
+    // Attach MAC-level traces to the sender NIC
+    Ptr<CsmaNetDevice> txDev = DynamicCast<CsmaNetDevice>(terminals.Get(clientI)->GetDevice(0));
+    if (txDev)
+    {
+        txDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("TX-host")));
+    }
+
+    // Attach MAC-level traces to the receiver NIC
+    Ptr<CsmaNetDevice> rxDev = DynamicCast<CsmaNetDevice>(terminals.Get(serverI)->GetDevice(0));
+    if (rxDev)
+    {
+        rxDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("RX-host")));
+    }
 
     if (enablePcap)
     {

--- a/examples/p4-psa-ipv4-forwarding.cc
+++ b/examples/p4-psa-ipv4-forwarding.cc
@@ -231,7 +231,7 @@ main(int argc, char* argv[])
     double simDuration = 20.0;         ///< Total simulation time (s).
     int model = 0;                     ///< 0 = P4 PSA switch;  1 = standard NS-3 bridge (baseline).
     bool enablePcap = true;            ///< Enable PCAP trace output.
-    int runnum = 0;                    ///< Run index for batch experiments.
+    int seednum = 1;                   ///< Run index for batch experiments.
 
     // Paths resolved via P4SIM_DIR environment variable (portable).
     std::string p4SrcDir = GetP4ExamplePath() + "/simple_psa";
@@ -257,8 +257,14 @@ main(int argc, char* argv[])
                  switchRate);
     cmd.AddValue("model", "Switch model: 0=P4 PSA, 1=NS-3 bridge baseline", model);
     cmd.AddValue("pcap", "Enable PCAP packet capture (true/false)", enablePcap);
-    cmd.AddValue("runnum", "Run index used for batch experiments", runnum);
+    cmd.AddValue("seednum", "Run index used for batch experiments", seednum);
     cmd.Parse(argc, argv);
+
+    // Apply runtime-configurable timing after parsing
+    client_stop_time = client_start_time + flowDuration;
+    sink_stop_time = client_stop_time + 5.0;
+
+    RngSeedManager::SetRun(seednum); // Set the random seed for reproducibility
 
     // ============================ topo -> network ============================
 
@@ -386,9 +392,9 @@ main(int argc, char* argv[])
     }
 
     // === Configuration for Link: h0 -----> h1 ===
-    unsigned int serverI = 1;
-    unsigned int clientI = 0;
-    uint16_t servPort = 9093; // UDP port for the server
+    unsigned int serverI = serverIndex;
+    unsigned int clientI = clientIndex;
+    uint16_t servPort = serverPort;
 
     // === Retrieve Server Address ===
     Ptr<Node> node = terminals.Get(serverI);
@@ -451,7 +457,7 @@ main(int argc, char* argv[])
     // Run simulation
     NS_LOG_INFO("Running simulation...");
     unsigned long simulate_start = getTickCount();
-    Simulator::Stop(Seconds(global_stop_time));
+    Simulator::Stop(Seconds(simDuration));
     Simulator::Run();
     Simulator::Destroy();
 

--- a/examples/p4-queue-test.cc
+++ b/examples/p4-queue-test.cc
@@ -82,11 +82,9 @@ ConvertIpToHex(Ipv4Address ipAddr)
 {
     std::ostringstream s;
     uint32_t ip = ipAddr.Get();
-    s << "0x" << std::hex << std::setfill('0')
-      << std::setw(2) << ((ip >> 24) & 0xFF)
-      << std::setw(2) << ((ip >> 16) & 0xFF)
-      << std::setw(2) << ((ip >>  8) & 0xFF)
-      << std::setw(2) << ( ip        & 0xFF);
+    s << "0x" << std::hex << std::setfill('0') << std::setw(2) << ((ip >> 24) & 0xFF)
+      << std::setw(2) << ((ip >> 16) & 0xFF) << std::setw(2) << ((ip >> 8) & 0xFF) << std::setw(2)
+      << (ip & 0xFF);
     return s.str();
 }
 
@@ -112,57 +110,55 @@ main(int argc, char* argv[])
     LogComponentEnable("P4QueueTest", LOG_LEVEL_INFO);
 
     // ---- tuneable parameters ----
-    int         runNum        = 0;
-    uint16_t    pktSize       = 1000;       // bytes per UDP payload
-    std::string appDataRate1  = "3Mbps";    // flow 1 (port1)
-    std::string appDataRate2  = "4Mbps";    // flow 2 (port2)
-    std::string appDataRate3  = "5Mbps";    // flow 3 (port3)
-    std::string linkRate      = "1000Mbps"; // P2P link data rate
-    std::string linkDelay     = "10us";     // P2P link propagation delay
-    uint32_t    switchRate    = 1500;       // switch processing rate (pps)
-    uint32_t    queueSize     = 1000;       // total queue buffer (packets)
-    uint16_t    port1         = 2000;       // UDP dst port for flow 1
-    uint16_t    port2         = 3000;       // UDP dst port for flow 2
-    uint16_t    port3         = 4000;       // UDP dst port for flow 3
-    uint32_t    serverIndex   = 1;          // host index acting as receiver
-    uint32_t    clientIndex   = 0;          // host index acting as sender
-    double      flowDuration  = 10.0;       // OnOff active duration (s)
-    double      simDuration   = 20.0;       // total simulation time (s)
-    bool        enablePcap    = true;
+    uint16_t pktSize = 1000;            // bytes per UDP payload
+    std::string appDataRate1 = "3Mbps"; // flow 1 (port1)
+    std::string appDataRate2 = "4Mbps"; // flow 2 (port2)
+    std::string appDataRate3 = "5Mbps"; // flow 3 (port3)
+    std::string linkRate = "1000Mbps";  // P2P link data rate
+    std::string linkDelay = "10us";     // P2P link propagation delay
+    uint32_t switchRate = 1500;         // switch processing rate (pps)
+    uint32_t queueSize = 1000;          // total queue buffer (packets)
+    uint16_t port1 = 2000;              // UDP dst port for flow 1
+    uint16_t port2 = 3000;              // UDP dst port for flow 2
+    uint16_t port3 = 4000;              // UDP dst port for flow 3
+    uint32_t serverIndex = 1;           // host index acting as receiver
+    uint32_t clientIndex = 0;           // host index acting as sender
+    double flowDuration = 10.0;         // OnOff active duration (s)
+    double simDuration = 20.0;          // total simulation time (s)
+    bool enablePcap = true;
 
     // P4 program paths
-    std::string p4SrcDir      = GetP4ExamplePath() + "/qos";
-    std::string p4JsonPath    = p4SrcDir + "/qos.json";
+    std::string p4SrcDir = GetP4ExamplePath() + "/qos";
+    std::string p4JsonPath = p4SrcDir + "/qos.json";
     std::string flowTablePath = p4SrcDir + "/flowtable_0.txt";
-    std::string topoInput     = p4SrcDir + "/topo.txt";
+    std::string topoInput = p4SrcDir + "/topo.txt";
 
     // ---- command line ----
     CommandLine cmd;
-    cmd.AddValue("runnum",       "Run index used in loop experiments",           runNum);
-    cmd.AddValue("pktSize",      "UDP payload size in bytes",                    pktSize);
-    cmd.AddValue("appDataRate1", "OnOff data rate for flow 1 (port1)",           appDataRate1);
-    cmd.AddValue("appDataRate2", "OnOff data rate for flow 2 (port2)",           appDataRate2);
-    cmd.AddValue("appDataRate3", "OnOff data rate for flow 3 (port3)",           appDataRate3);
-    cmd.AddValue("linkRate",     "P2P link data rate",                           linkRate);
-    cmd.AddValue("linkDelay",    "P2P link propagation delay",                   linkDelay);
-    cmd.AddValue("switchRate",   "Switch processing rate in packets per second", switchRate);
-    cmd.AddValue("queueSize",    "Total queue buffer size in packets",           queueSize);
-    cmd.AddValue("port1",        "UDP destination port for flow 1",              port1);
-    cmd.AddValue("port2",        "UDP destination port for flow 2",              port2);
-    cmd.AddValue("port3",        "UDP destination port for flow 3",              port3);
-    cmd.AddValue("serverIndex",  "Host index acting as UDP receiver",            serverIndex);
-    cmd.AddValue("clientIndex",  "Host index acting as UDP sender",              clientIndex);
-    cmd.AddValue("flowDuration", "Duration of each OnOff flow (s)",             flowDuration);
-    cmd.AddValue("simDuration",  "Total simulation duration (s)",                simDuration);
-    cmd.AddValue("pcap",         "Enable PCAP tracing",                          enablePcap);
+    cmd.AddValue("pktSize", "UDP payload size in bytes", pktSize);
+    cmd.AddValue("appDataRate1", "OnOff data rate for flow 1 (port1)", appDataRate1);
+    cmd.AddValue("appDataRate2", "OnOff data rate for flow 2 (port2)", appDataRate2);
+    cmd.AddValue("appDataRate3", "OnOff data rate for flow 3 (port3)", appDataRate3);
+    cmd.AddValue("linkRate", "P2P link data rate", linkRate);
+    cmd.AddValue("linkDelay", "P2P link propagation delay", linkDelay);
+    cmd.AddValue("switchRate", "Switch processing rate in packets per second", switchRate);
+    cmd.AddValue("queueSize", "Total queue buffer size in packets", queueSize);
+    cmd.AddValue("port1", "UDP destination port for flow 1", port1);
+    cmd.AddValue("port2", "UDP destination port for flow 2", port2);
+    cmd.AddValue("port3", "UDP destination port for flow 3", port3);
+    cmd.AddValue("serverIndex", "Host index acting as UDP receiver", serverIndex);
+    cmd.AddValue("clientIndex", "Host index acting as UDP sender", clientIndex);
+    cmd.AddValue("flowDuration", "Duration of each OnOff flow (s)", flowDuration);
+    cmd.AddValue("simDuration", "Total simulation duration (s)", simDuration);
+    cmd.AddValue("pcap", "Enable PCAP tracing", enablePcap);
     cmd.Parse(argc, argv);
 
     // Derive timing
-    const double sinkStart   = 0.0;
+    const double sinkStart = 0.0;
     const double clientStart = 0.0;
-    const double clientStop  = clientStart + flowDuration;
-    const double sinkStop    = clientStop  + 5.0;
-    const double simStop     = std::max(simDuration, sinkStop + 1.0);
+    const double clientStop = clientStart + flowDuration;
+    const double sinkStop = clientStop + 5.0;
+    const double simStop = std::max(simDuration, sinkStop + 1.0);
 
     // ============================ topo -> network ============================
 
@@ -178,16 +174,16 @@ main(int argc, char* argv[])
         return -1;
     }
 
-    NodeContainer terminals  = topoReader->GetHostNodeContainer();
+    NodeContainer terminals = topoReader->GetHostNodeContainer();
     NodeContainer switchNode = topoReader->GetSwitchNodeContainer();
-    const uint32_t hostNum   = terminals.GetN();
+    const uint32_t hostNum = terminals.GetN();
     const uint32_t switchNum = switchNode.GetN();
     NS_LOG_INFO("Hosts: " << hostNum << "  Switches: " << switchNum);
 
     // ---- link installation ----
     P4PointToPointHelper p4p2p;
-    p4p2p.SetDeviceAttribute ("DataRate", DataRateValue(DataRate(linkRate)));
-    p4p2p.SetChannelAttribute("Delay",    TimeValue(Time(linkDelay)));
+    p4p2p.SetDeviceAttribute("DataRate", DataRateValue(DataRate(linkRate)));
+    p4p2p.SetChannelAttribute("Delay", TimeValue(Time(linkDelay)));
 
     NetDeviceContainer hostDevices;
     NetDeviceContainer switchDevices;
@@ -196,11 +192,26 @@ main(int argc, char* argv[])
         NetDeviceContainer link =
             p4p2p.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
         char from = iter->GetFromType();
-        char to   = iter->GetToType();
-        if      (from == 's' && to == 's') { switchDevices.Add(link.Get(0)); switchDevices.Add(link.Get(1)); }
-        else if (from == 's' && to == 'h') { switchDevices.Add(link.Get(0)); hostDevices.Add(link.Get(1)); }
-        else if (from == 'h' && to == 's') { hostDevices.Add(link.Get(0));   switchDevices.Add(link.Get(1)); }
-        else { NS_ABORT_MSG("Unexpected link type: " << from << "-" << to); }
+        char to = iter->GetToType();
+        if (from == 's' && to == 's')
+        {
+            switchDevices.Add(link.Get(0));
+            switchDevices.Add(link.Get(1));
+        }
+        else if (from == 's' && to == 'h')
+        {
+            switchDevices.Add(link.Get(0));
+            hostDevices.Add(link.Get(1));
+        }
+        else if (from == 'h' && to == 's')
+        {
+            hostDevices.Add(link.Get(0));
+            switchDevices.Add(link.Get(1));
+        }
+        else
+        {
+            NS_ABORT_MSG("Unexpected link type: " << from << "-" << to);
+        }
     }
 
     // ---- IP stack ----
@@ -217,26 +228,23 @@ main(int argc, char* argv[])
     NS_LOG_INFO("Node IP / MAC addresses:");
     for (uint32_t i = 0; i < hostNum; ++i)
     {
-        Ptr<Node>    node   = terminals.Get(i);
-        Ipv4Address  ipAddr = node->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal();
-        Mac48Address mac    = Mac48Address::ConvertFrom(node->GetDevice(0)->GetAddress());
-        NS_LOG_INFO("  Host[" << i << "]  IP=" << ipAddr
-                    << " (" << ConvertIpToHex(ipAddr) << ")"
-                    << "  MAC=" << mac
-                    << " (" << ConvertMacToHex(mac) << ")");
+        Ptr<Node> node = terminals.Get(i);
+        Ipv4Address ipAddr = node->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal();
+        Mac48Address mac = Mac48Address::ConvertFrom(node->GetDevice(0)->GetAddress());
+        NS_LOG_INFO("  Host[" << i << "]  IP=" << ipAddr << " (" << ConvertIpToHex(ipAddr) << ")"
+                              << "  MAC=" << mac << " (" << ConvertMacToHex(mac) << ")");
     }
 
     // ---- P4 switch ----
-    NS_LOG_INFO("Configuring P4 switch: " << p4JsonPath
-                << "  switchRate=" << switchRate << " pps"
-                << "  queueSize=" << queueSize);
+    NS_LOG_INFO("Configuring P4 switch: " << p4JsonPath << "  switchRate=" << switchRate << " pps"
+                                          << "  queueSize=" << queueSize);
     P4Helper p4SwitchHelper;
-    p4SwitchHelper.SetDeviceAttribute("JsonPath",        StringValue(p4JsonPath));
-    p4SwitchHelper.SetDeviceAttribute("FlowTablePath",   StringValue(flowTablePath));
-    p4SwitchHelper.SetDeviceAttribute("EnableTracing",   BooleanValue(true));
-    p4SwitchHelper.SetDeviceAttribute("ChannelType",     UintegerValue(1));  // P2P
-    p4SwitchHelper.SetDeviceAttribute("P4SwitchArch",    UintegerValue(0));  // V1model
-    p4SwitchHelper.SetDeviceAttribute("SwitchRate",      UintegerValue(switchRate));
+    p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
+    p4SwitchHelper.SetDeviceAttribute("FlowTablePath", StringValue(flowTablePath));
+    p4SwitchHelper.SetDeviceAttribute("EnableTracing", BooleanValue(true));
+    p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(1));  // P2P
+    p4SwitchHelper.SetDeviceAttribute("P4SwitchArch", UintegerValue(0)); // V1model
+    p4SwitchHelper.SetDeviceAttribute("SwitchRate", UintegerValue(switchRate));
     p4SwitchHelper.SetDeviceAttribute("QueueBufferSize", UintegerValue(queueSize));
     for (uint32_t i = 0; i < switchNum; ++i)
         p4SwitchHelper.Install(switchNode.Get(i), switchDevices);
@@ -244,12 +252,11 @@ main(int argc, char* argv[])
     // ---- retrieve server address ----
     Ipv4Address serverAddr =
         terminals.Get(serverIndex)->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal();
-    NS_LOG_INFO("Server: Host[" << serverIndex << "]  " << serverAddr
-                << "  Client: Host[" << clientIndex << "]");
+    NS_LOG_INFO("Server: Host[" << serverIndex << "]  " << serverAddr << "  Client: Host["
+                                << clientIndex << "]");
 
     // ---- helper lambda: install one sink + one OnOff flow ----
-    auto installFlow = [&](uint16_t port, const std::string& rate, const std::string& label)
-    {
+    auto installFlow = [&](uint16_t port, const std::string& rate, const std::string& label) {
         InetSocketAddress dst(serverAddr, port);
 
         PacketSinkHelper sinkHelper("ns3::UdpSocketFactory", dst);
@@ -259,9 +266,9 @@ main(int argc, char* argv[])
 
         OnOffHelper onOff("ns3::UdpSocketFactory", dst);
         onOff.SetAttribute("PacketSize", UintegerValue(pktSize));
-        onOff.SetAttribute("DataRate",   StringValue(rate));
-        onOff.SetAttribute("OnTime",     StringValue("ns3::ConstantRandomVariable[Constant=1]"));
-        onOff.SetAttribute("OffTime",    StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+        onOff.SetAttribute("DataRate", StringValue(rate));
+        onOff.SetAttribute("OnTime", StringValue("ns3::ConstantRandomVariable[Constant=1]"));
+        onOff.SetAttribute("OffTime", StringValue("ns3::ConstantRandomVariable[Constant=0]"));
 
         ApplicationContainer clientApp = onOff.Install(terminals.Get(clientIndex));
         clientApp.Start(Seconds(clientStart));

--- a/examples/p4-source-routing.cc
+++ b/examples/p4-source-routing.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 TU Dresden
+ * Copyright (c) 2026 TU Dresden
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -14,27 +14,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- * Authors: Mingyu Ma <mingyu.ma@tu-dresden.de>
- *
- */
-
-/**
- * This example is same with "basic exerciese" in p4lang/tutorials
- * URL: https://github.com/p4lang/tutorials/tree/master/exercises/basic
- * The P4 program implements basic ipv4 forwarding, also with ARP.
- *
- *          ┌──────────┐              ┌──────────┐
- *          │ Switch 2 \\            /│ Switch 3 │
- *          └─────┬────┘  \        // └──────┬───┘
- *                │         \    /           │
- *                │           /              │
- *          ┌─────┴────┐   /   \      ┌──────┴───┐
- *          │ Switch 0 //         \ \ │ Switch 1 │
- *      ┌───┼          │             \\          ┼────┐
- *      │   └────────┬─┘              └┬─────────┘    │
- *  ┌───┼────┐     ┌─┴──────┐    ┌─────┼──┐     ┌─────┼──┐
- *  │ host 4 │     │ host 5 │    │ host 6 │     │ host 7 │
- *  └────────┘     └────────┘    └────────┘     └────────┘
+ * Authors: Vineet Goel <vineetgoel692@gmail.com>
+ *          Mingyu Ma <mingyu.ma@tu-dresden.de>
  */
 
 #include "ns3/applications-module.h"
@@ -43,6 +24,8 @@
 #include "ns3/csma-helper.h"
 #include "ns3/format-utils.h"
 #include "ns3/internet-module.h"
+#include "ns3/ipv4-header.h"
+#include "ns3/loopback-net-device.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
 #include "ns3/p4-topology-reader-helper.h"
@@ -50,115 +33,138 @@
 #include "ns3/packet-socket-factory.h"
 #include "ns3/packet-socket-helper.h"
 #include "ns3/udp-header.h"
-#include "ns3/ipv4-header.h"
-#include "ns3/loopback-net-device.h"
 
 #include <filesystem>
 #include <iomanip>
+#include <sstream>
 
 using namespace ns3;
-NS_LOG_COMPONENT_DEFINE("P4SrcRoutingExample");
-// NS_LOG_COMPONENT_DEFINE("P4BasicExample");
-
+NS_LOG_COMPONENT_DEFINE("P4SrcRouting");
 
 class SrcRouteHeader : public Header
 {
   public:
-  struct Hop{
-    uint16_t port;
-    bool bos;
-  };
+    struct Hop
+    {
+        uint16_t port;
+        bool bos;
+    };
 
-  std::vector<Hop> hops;
-    SrcRouteHeader() {}
+    std::vector<Hop> hops;
+
+    SrcRouteHeader()
+    {
+    }
+
     static TypeId GetTypeId()
     {
         static TypeId tid = TypeId("SrcRouteHeader").SetParent<Header>().SetGroupName("Tutorial");
         return tid;
     }
-    void AddHop(uint16_t port, bool bos) {
+
+    void AddHop(uint16_t port, bool bos)
+    {
         Hop hop = {port, bos};
         hops.push_back(hop);
     }
-    virtual TypeId GetInstanceTypeId() const override { return GetTypeId(); }
-    virtual void Print(std::ostream& os) const override { os << "SrcRouteHeader"; }
-    virtual uint32_t GetSerializedSize() const override { return hops.size()*2; }
-    virtual void Serialize(Buffer::Iterator start) const override {
-        for (auto &h:hops){
-            uint16_t val=(h.bos<<15) | (h.port & 0x7FFF);
+
+    virtual TypeId GetInstanceTypeId() const override
+    {
+        return GetTypeId();
+    }
+
+    virtual void Print(std::ostream& os) const override
+    {
+        os << "SrcRouteHeader";
+    }
+
+    virtual uint32_t GetSerializedSize() const override
+    {
+        return hops.size() * 2;
+    }
+
+    virtual void Serialize(Buffer::Iterator start) const override
+    {
+        for (auto& h : hops)
+        {
+            uint16_t val = (h.bos << 15) | (h.port & 0x7FFF);
             start.WriteHtonU16(val);
         }
     }
-    virtual uint32_t Deserialize(Buffer::Iterator start) override { return 0; }
+
+    virtual uint32_t Deserialize(Buffer::Iterator start) override
+    {
+        return 0;
+    }
 };
 
 class SourceRoutingApp : public Application
 {
-public:
+  public:
     SourceRoutingApp() = default;
     virtual ~SourceRoutingApp() = default;
 
-    void Setup(
-        Ipv4Address dst,
-        uint16_t port,
-        uint32_t pktSize,
-        DataRate dataRate,
-        std::vector<uint16_t> pathPorts)
+    void Setup(Ipv4Address dst,
+               uint16_t port,
+               uint32_t pktSize,
+               DataRate dataRate,
+               std::vector<uint16_t> pathPorts,
+               uint32_t maxPkts = 0)
     {
         m_dst = dst;
         m_port = port;
         m_pktSize = pktSize;
         m_dataRate = dataRate;
         m_pathPorts = pathPorts;
+        m_maxPkts = maxPkts;
     }
 
     static TypeId GetTypeId()
     {
-        static TypeId tid = TypeId("SourceRoutingApp")
-            .SetParent<Application>()
-            .SetGroupName("Tutorial")
-            .AddConstructor<SourceRoutingApp>()
-            .AddTraceSource("Tx", "A new packet is created and is sent",
-                            MakeTraceSourceAccessor(&SourceRoutingApp::m_txTrace),
-                            "ns3::Packet::TracedCallback");
+        static TypeId tid =
+            TypeId("SourceRoutingApp")
+                .SetParent<Application>()
+                .SetGroupName("Tutorial")
+                .AddConstructor<SourceRoutingApp>()
+                .AddTraceSource("Tx",
+                                "A new packet is created and is sent",
+                                MakeTraceSourceAccessor(&SourceRoutingApp::m_txTrace),
+                                "ns3::Packet::TracedCallback");
         return tid;
     }
 
-private:
+  private:
     void StartApplication() override
     {
-    NS_ASSERT(GetNode());
-    m_socket = Socket::CreateSocket(
-        GetNode(), PacketSocketFactory::GetTypeId());
+        NS_ASSERT(GetNode());
+        m_socket = Socket::CreateSocket(GetNode(), PacketSocketFactory::GetTypeId());
 
-    NS_ASSERT(m_socket);
+        NS_ASSERT(m_socket);
 
-
-    
-    // Find non-loopback device
-    Ptr<NetDevice> targetDevice = nullptr;
-    for (uint32_t i = 0; i < GetNode()->GetNDevices(); i++)
-    {
-        Ptr<NetDevice> d = GetNode()->GetDevice(i);
-        if (!DynamicCast<LoopbackNetDevice>(d))
+        // Find non-loopback device
+        Ptr<NetDevice> targetDevice = nullptr;
+        for (uint32_t i = 0; i < GetNode()->GetNDevices(); i++)
         {
-            targetDevice = d;
-            break;
+            Ptr<NetDevice> d = GetNode()->GetDevice(i);
+            if (!DynamicCast<LoopbackNetDevice>(d))
+            {
+                targetDevice = d;
+                break;
+            }
         }
-    }
-    NS_ASSERT_MSG(targetDevice, "No suitable network device found");
+        NS_ASSERT_MSG(targetDevice, "No suitable network device found");
 
-    m_socketAddr.SetSingleDevice(targetDevice->GetIfIndex());
-    m_socketAddr.SetPhysicalAddress(targetDevice->GetBroadcast());
-    m_socketAddr.SetProtocol(0x1234);
+        m_socketAddr.SetSingleDevice(targetDevice->GetIfIndex());
+        m_socketAddr.SetPhysicalAddress(targetDevice->GetBroadcast());
+        m_socketAddr.SetProtocol(0x1234);
 
-    //m_socket->Connect(m_socketAddr);
-    SendPacket();
+        SendPacket();
     }
 
     void StopApplication() override
     {
-        if (m_event.IsRunning()) {
+        if (m_event.IsRunning())
+        {
             m_event.Cancel();
         }
         if (m_socket)
@@ -170,9 +176,21 @@ private:
 
     void SendPacket()
     {
-        if(!m_socket)
+        if (!m_socket)
             return;
-        NS_LOG_INFO("Sending SR packet with "<<m_pathPorts.size()<<" hops to "<<m_dst);
+        m_pktCount++;
+        std::ostringstream portList;
+        for (size_t i = 0; i < m_pathPorts.size(); i++)
+        {
+            if (i)
+                portList << " -> ";
+            portList << "port " << m_pathPorts[i];
+            if (i == m_pathPorts.size() - 1)
+                portList << " (bos)";
+        }
+        NS_LOG_INFO("[pkt #" << m_pktCount << "] t=" << Simulator::Now().GetSeconds()
+                             << "s  hops=" << m_pathPorts.size() << "  path: " << portList.str()
+                             << "  dst=" << m_dst);
         Ptr<Packet> pkt = Create<Packet>(m_pktSize);
 
         SrcRouteHeader sr;
@@ -194,7 +212,7 @@ private:
         ipv4.SetProtocol(17); // UDP
         ipv4.SetTtl(64);
         ipv4.SetPayloadSize(m_pktSize + udp.GetSerializedSize());
-        
+
         udp.InitializeChecksum(srcIp, m_dst, 17);
         ipv4.EnableChecksum();
 
@@ -203,18 +221,29 @@ private:
         pkt->AddHeader(sr);
         m_txTrace(pkt);
         int ret = m_socket->SendTo(pkt, 0, m_socketAddr);
-        if (ret < 0) {
+        if (ret < 0)
+        {
             NS_LOG_INFO("Send failed, errno: " << m_socket->GetErrno());
-        } else {
+        }
+        else
+        {
             NS_LOG_INFO("Sent packet, ret=" << ret);
         }
 
-        Time next = Seconds(
-            (double)m_pktSize * 8 / m_dataRate.GetBitRate());
-        if(next>Seconds(0)){m_event = Simulator::Schedule(next, &SourceRoutingApp::SendPacket, this);}
+        if (m_maxPkts > 0 && m_pktCount >= m_maxPkts)
+        {
+            NS_LOG_INFO("[pkt #" << m_pktCount << "] Reached maxPkts=" << m_maxPkts
+                                 << ", stopping.");
+            return;
+        }
+        Time next = Seconds((double)m_pktSize * 8 / m_dataRate.GetBitRate());
+        if (next > Seconds(0))
+        {
+            m_event = Simulator::Schedule(next, &SourceRoutingApp::SendPacket, this);
+        }
     }
 
-private:
+  private:
     Ptr<Socket> m_socket;
     EventId m_event;
     Ipv4Address m_dst;
@@ -222,11 +251,11 @@ private:
     uint32_t m_pktSize;
     DataRate m_dataRate;
     std::vector<uint16_t> m_pathPorts;
+    uint32_t m_maxPkts{0};
+    uint32_t m_pktCount{0};
     TracedCallback<Ptr<const Packet>> m_txTrace;
     PacketSocketAddress m_socketAddr;
 };
-
-
 
 unsigned long start = getTickCount();
 double global_start_time = 1.0;
@@ -235,17 +264,6 @@ double client_start_time = sink_start_time + 1.0;
 double client_stop_time = client_start_time + 3;
 double sink_stop_time = client_stop_time + 5;
 double global_stop_time = sink_stop_time + 5;
-
-bool first_tx = true;
-bool first_rx = true;
-int counter_sender_10 = 10;
-int counter_receiver_10 = 10;
-double first_packet_send_time_tx = 0.0;
-double last_packet_send_time_tx = 0.0;
-double first_packet_received_time_rx = 0.0;
-double last_packet_received_time_rx = 0.0;
-uint64_t totalTxBytes = 0;
-uint64_t totalRxBytes = 0;
 
 // Convert IP address to hexadecimal format
 std::string
@@ -278,72 +296,6 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-void
-TxCallback(Ptr<const Packet> packet)
-{
-    NS_LOG_INFO("TxCallback invoked");
-    if (first_tx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
-        first_packet_send_time_tx = Simulator::Now().GetSeconds();
-        counter_sender_10--;
-        if (counter_sender_10 == 0)
-        {
-            first_tx = false;
-        }
-    }
-    else
-    {
-        totalTxBytes += packet->GetSize();
-        last_packet_send_time_tx = Simulator::Now().GetSeconds();
-    }
-}
-
-void
-RxCallback(Ptr<const Packet> packet, const Address& addr)
-{
-    NS_LOG_INFO("RxCallback invoked");
-    if (first_rx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
-        first_packet_received_time_rx = Simulator::Now().GetSeconds();
-        counter_receiver_10--;
-        if (counter_receiver_10 == 0)
-        {
-            first_rx = false;
-        }
-    }
-    else
-    {
-        totalRxBytes += packet->GetSize();
-        last_packet_received_time_rx = Simulator::Now().GetSeconds();
-    }
-}
-
-void
-PrintFinalThroughput()
-{
-    double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
-    double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
-
-    double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-    std::cout << "client_start_time: " << first_packet_send_time_tx
-              << "client_stop_time: " << last_packet_send_time_tx
-              << "sink_start_time: " << first_packet_received_time_rx
-              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
-
-    std::cout << "======================================" << std::endl;
-    std::cout << "Final Simulation Results:" << std::endl;
-    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
-              << std::endl;
-    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
-              << std::endl;
-    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
-    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
-    std::cout << "======================================" << std::endl;
-}
-
 // ============================ data struct ============================
 struct SwitchNodeC_t
 {
@@ -363,14 +315,13 @@ struct HostNodeC_t
 int
 main(int argc, char* argv[])
 {
-    // LogComponentEnable("P4BasicExample", LOG_LEVEL_INFO);
-    LogComponentEnable("P4SrcRoutingExample", LOG_LEVEL_INFO);
+    LogComponentEnable("P4SrcRouting", LOG_LEVEL_INFO);
 
     // ============================ parameters ============================
-    int running_number = 0;
-    uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments, default 512
+    uint16_t pktSize = 1000;           // in Bytes. 1458 to prevent fragments default 512
     std::string appDataRate = "3Mbps"; // Default application data rate
-    std::string ns3_link_rate = "1000Mbps";
+    std::string linkRate = "1000Mbps"; // Default link data rate
+    std::string linkDelay = "0.01ms";  // Default link delay
     bool enableTracePcap = true;
 
     // Use P4SIM_DIR environment variable for portable paths
@@ -379,13 +330,28 @@ main(int argc, char* argv[])
     std::string topoInput = p4SrcDir + "/topo.txt";
     std::string topoFormat("CsmaTopo");
 
+    std::string pathStr = "1,2,0"; // default path: h0->s0(p1)->s1(p2)->s2(p0)->h2
+
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
-    cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
-    cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
+    cmd.AddValue("appDataRate", "OnOff application data rate, e.g. 3Mbps", appDataRate);
+    // cmd.AddValue("linkRate", "CSMA link data rate, e.g. 1000Mbps", linkRate);
+    // cmd.AddValue("linkDelay", "CSMA link one-way delay, e.g. 0.01ms", linkDelay);
+    cmd.AddValue("pcap", "Trace packet pcap [true] or not[false]", enableTracePcap);
+    cmd.AddValue("path", "Comma-separated egress port list, e.g. \"1,2,0\"", pathStr);
     cmd.Parse(argc, argv);
+
+    std::vector<uint16_t> path;
+    {
+        std::istringstream ss(pathStr);
+        std::string token;
+        while (std::getline(ss, token, ','))
+        {
+            path.push_back(static_cast<uint16_t>(std::stoi(token)));
+        }
+    }
+    NS_ASSERT_MSG(!path.empty(), "path must have at least one hop");
 
     // ============================ topo -> network ============================
     P4TopologyReaderHelper p4TopoHelper;
@@ -414,11 +380,9 @@ main(int argc, char* argv[])
 
     // set default network link parameter
     CsmaHelper csma;
-    csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
-    csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
+    csma.SetChannelAttribute("DataRate", StringValue(linkRate));
+    csma.SetChannelAttribute("Delay", StringValue(linkDelay));
 
-    // NetDeviceContainer hostDevices;
-    // NetDeviceContainer switchDevices;
     P4TopologyReader::ConstLinksIterator_t iter;
     SwitchNodeC_t switchNodes[switchNum];
     HostNodeC_t hostNodes[hostNum];
@@ -494,13 +458,9 @@ main(int argc, char* argv[])
         }
     }
 
-    // ========================Print the Channel Type and NetDevice Type========================
-
     InternetStackHelper internet;
     internet.Install(terminals);
     internet.Install(switchNode);
-    
-
 
     Ipv4AddressHelper ipv4;
     ipv4.SetBase("10.1.1.0", "255.255.255.0");
@@ -519,16 +479,8 @@ main(int argc, char* argv[])
     {
         Ptr<Node> node = terminals.Get(i);
         Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-        Ptr<NetDevice> netDevice = node->GetDevice(0);
-
-        // Get the IP address
-        Ipv4Address ipAddr =
-            ipv4->GetAddress(1, 0)
-                .GetLocal(); // Interface index 1 corresponds to the first assigned IP
-
-        // Get the MAC address
-        Ptr<NetDevice> device = node->GetDevice(0); // Assuming the first device is the desired one
-        Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
+        Ipv4Address ipAddr = ipv4->GetAddress(1, 0).GetLocal();
+        Mac48Address mac = Mac48Address::ConvertFrom(node->GetDevice(0)->GetAddress());
 
         NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
 
@@ -546,10 +498,6 @@ main(int argc, char* argv[])
 
     for (unsigned int i = 0; i < switchNum; i++)
     {
-        // std::string flowTablePath = flowTableDirPath + "flowtable_" + std::to_string(i) + ".txt";
-        // p4SwitchHelper.SetDeviceAttribute("FlowTablePath", StringValue(flowTablePath));
-        // NS_LOG_INFO("*** P4 switch configuration: " << p4JsonPath << ", \n " << flowTablePath);
-
         p4SwitchHelper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
     }
 
@@ -570,40 +518,38 @@ main(int argc, char* argv[])
     sinkApp1.Start(Seconds(sink_start_time));
     sinkApp1.Stop(Seconds(sink_stop_time));
 
-    // === Setup OnOff Application on Client ===
-    // OnOffHelper onOff1("ns3::UdpSocketFactory", dst1);
-    // onOff1.SetAttribute("PacketSize", UintegerValue(pktSize));
-    // onOff1.SetAttribute("DataRate", StringValue(appDataRate));
-    // onOff1.SetAttribute("OnTime", StringValue("ns3::ConstantRandomVariable[Constant=1]"));
-    // onOff1.SetAttribute("OffTime", StringValue("ns3::ConstantRandomVariable[Constant=0]"));
+    // === Print human-readable path: resolve port numbers to node names ===
+    {
+        std::ostringstream pathDesc;
+        pathDesc << "h" << clientI;
+        unsigned int curSwitch = hostNodes[clientI].linkSwitchIndex;
+        for (size_t i = 0; i < path.size(); i++)
+        {
+            uint16_t port = path[i];
+            pathDesc << " -> s" << curSwitch << "(port " << port << ")";
+            const std::string& info = switchNodes[curSwitch].switchPortInfos[port];
+            if (info[0] == 'h')
+            {
+                pathDesc << " -> h" << info.substr(1);
+            }
+            else
+            {
+                size_t upos = info.find('_');
+                curSwitch = std::stoi(info.substr(1, upos - 1));
+            }
+        }
+        std::cout << "*** Forwarding path: " << pathDesc.str() << std::endl;
+    }
 
-    std::vector<uint16_t> path={1,2,0};
-    Ptr<SourceRoutingApp> app=CreateObject<SourceRoutingApp>();
-    app->Setup(serverAddr1, servPort, pktSize, DataRate(appDataRate), path);
+    Ptr<SourceRoutingApp> app = CreateObject<SourceRoutingApp>();
+    app->Setup(serverAddr1, servPort, pktSize, DataRate(appDataRate), path, 2);
     terminals.Get(clientI)->AddApplication(app);
     app->SetStartTime(Seconds(client_start_time));
     app->SetStopTime(Seconds(client_stop_time));
 
-    // === Setup Tracing ===
-    NS_LOG_INFO("Client node has " << terminals.Get(clientI)->GetNApplications() << " applications");
-    Ptr<Application> genericApp = terminals.Get(clientI)->GetApplication(0);
-    NS_LOG_INFO("Generic application pointer: " << genericApp);
-    
-    Ptr<SourceRoutingApp> ptr_app1 =
-        DynamicCast<SourceRoutingApp>(genericApp);
-    NS_LOG_INFO("Casted application pointer: " << ptr_app1);
-
-    if (ptr_app1) {
-        ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-    } else {
-        NS_LOG_ERROR("Failed to cast application to SourceRoutingApp");
-    }
-
-    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
-
     if (enableTracePcap)
     {
-        csma.EnablePcapAll("p4-basic-example");
+        csma.EnablePcapAll("p4-source-routing", true);
     }
 
     // Run simulation
@@ -618,8 +564,6 @@ main(int argc, char* argv[])
                                           << "Total Running time: " << end - start << "ms"
                                           << std::endl
                                           << "Run successfully!");
-
-    PrintFinalThroughput();
 
     return 0;
 }

--- a/examples/p4-spine-leaf-topo.cc
+++ b/examples/p4-spine-leaf-topo.cc
@@ -33,7 +33,7 @@
 
 using namespace ns3;
 
-NS_LOG_COMPONENT_DEFINE("SpineLeafTopology");
+NS_LOG_COMPONENT_DEFINE("P4SpineLeafTopo");
 
 unsigned long start = getTickCount();
 double global_start_time = 1.0;
@@ -255,11 +255,9 @@ CalculateThroughput()
 int
 main(int argc, char* argv[])
 {
-    LogComponentEnable("SpineLeafTopology", LOG_LEVEL_INFO);
+    LogComponentEnable("P4SpineLeafTopo", LOG_LEVEL_INFO);
 
-    int running_number = 0;
-    uint16_t pktSize = 1000; // in Bytes. 1458 to prevent fragments, default 512
-    int model = 0;
+    uint16_t pktSize = 1000;            // in Bytes. 1458 to prevent fragments, default 512
     std::string appDataRate = "10Mbps"; // Default application data rate
     bool enableTracePcap = false;
 
@@ -272,11 +270,9 @@ main(int argc, char* argv[])
 
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
-    cmd.AddValue("model", "running simulation with p4switch: 0, with ns-3 bridge: 1", model);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
     cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
-    cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
+    cmd.AddValue("pcap", "Trace packet pcap [true] or not[false]", enableTracePcap);
     cmd.Parse(argc, argv);
 
     // ============================ topo -> network ============================

--- a/examples/p4-topo-fattree.cc
+++ b/examples/p4-topo-fattree.cc
@@ -98,12 +98,12 @@ main(int argc, char* argv[])
     LogComponentEnable("P4TopoFattree", LOG_LEVEL_INFO);
     LogComponentEnable("P4TopologyReader", LOG_LEVEL_INFO);
 
-    int running_number = 0;
     int podNum = 2;
     bool enableBuildTableEntry = true;
     uint16_t pktSize = 1000; // in Bytes. 1458 to prevent fragments, default 512
     int model = 0;
     std::string appDataRate = "1Mbps"; // Default application data rate
+    uint32_t maxBytes = 1000;
     bool enableTracePcap = false;
 
     // Use P4SIM_DIR environment variable for portable paths
@@ -115,12 +115,14 @@ main(int argc, char* argv[])
 
     // ============================  command line ============================
     CommandLine cmd;
-    cmd.AddValue("runnum", "running number in loops", running_number);
     cmd.AddValue("podnum", "Numbers of built tree topo levels", podNum);
     cmd.AddValue("tableEntry", "Build the table entry [true] or not[false]", enableBuildTableEntry);
     cmd.AddValue("model", "running simulation with p4switch: 0, with ns-3 bridge: 1", model);
     cmd.AddValue("pktSize", "Packet size in bytes (default 1000)", pktSize);
     cmd.AddValue("appDataRate", "Application data rate in bps (default 1Mbps)", appDataRate);
+    cmd.AddValue("maxBytes",
+                 "Maximum bytes to send per flow, 0 = unlimited (default 1000)",
+                 maxBytes);
     cmd.AddValue("pcap", "Trace packet pacp [true] or not[false]", enableTracePcap);
     cmd.Parse(argc, argv);
 
@@ -400,7 +402,7 @@ main(int argc, char* argv[])
         OnOffHelper onOff = OnOffHelper("ns3::UdpSocketFactory", dst);
         onOff.SetAttribute("PacketSize", UintegerValue(pktSize));
         onOff.SetAttribute("DataRate", StringValue(appDataRate));
-        onOff.SetAttribute("MaxBytes", UintegerValue(1000));
+        onOff.SetAttribute("MaxBytes", UintegerValue(maxBytes));
 
         apps = onOff.Install(hosts.Get(i));
         apps.Start(Seconds(client_start_time));

--- a/examples/p4-v1model-ipv4-forwarding.cc
+++ b/examples/p4-v1model-ipv4-forwarding.cc
@@ -175,33 +175,32 @@ PrintFinalThroughput()
     double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
     double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
-    // Both TX and RX throughput use send_time as denominator:
-    // RX elapsed_time can be shorter than send_time when the last sent packet
-    // is still in flight (pipeline effect), which would inflate RX throughput.
-    // Using send_time gives a fair apples-to-apples comparison.
-    double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-    double finalRxThroughput = (totalRxBytes * 8.0) / (send_time * 1e6);
+    double finalTxThroughput = (send_time > 0) ? (totalTxBytes * 8.0) / (send_time * 1e6) : 0.0;
+    double finalRxThroughput =
+        (elapsed_time > 0) ? (totalRxBytes * 8.0) / (elapsed_time * 1e6) : 0.0;
     double pktDeliveryRatio =
         (totalTxBytes > 0) ? (double)totalRxBytes / totalTxBytes * 100.0 : 0.0;
 
     double macTxTime = lastMacTxTime - firstMacTxTime;
-    // double macRxTime = lastMacRxTime - firstMacRxTime;
+    double macRxTime = lastMacRxTime - firstMacRxTime;
     double macTxThroughput = (macTxTime > 0) ? (macTxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
-    double macRxThroughput = (macTxTime > 0) ? (macRxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
+    double macRxThroughput = (macRxTime > 0) ? (macRxBytes * 8.0) / (macRxTime * 1e6) : 0.0;
 
     std::cout << "======================================" << std::endl;
     std::cout << "Final Simulation Results:" << std::endl;
-    std::cout << "  ** [App Layer]  (window = send_time = " << send_time << "s)" << std::endl;
-    std::cout << "  TX: " << totalTxBytes << " bytes  |  RX: " << totalRxBytes
-              << " bytes  |  PDR: " << pktDeliveryRatio << "%" << std::endl;
+    std::cout << "  ** [App Layer]" << std::endl;
+    std::cout << "  PDR: " << pktDeliveryRatio << "%" << std::endl;
+    std::cout << "  TX: " << totalTxBytes << " bytes  (" << first_packet_send_time_tx << "s -> "
+              << last_packet_send_time_tx << "s,  elapsed=" << send_time << "s)" << std::endl;
+    std::cout << "  RX: " << totalRxBytes << " bytes  (" << first_packet_received_time_rx << "s -> "
+              << last_packet_received_time_rx << "s,  elapsed=" << elapsed_time << "s)" << std::endl;
     std::cout << "  TX Throughput: " << finalTxThroughput << " Mbps" << std::endl;
-    std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps  "
-              << "(RX elapsed=" << elapsed_time << "s)" << std::endl;
-    std::cout << "  ** [MAC Layer]  (window = macTxTime = " << macTxTime << "s)" << std::endl;
-    std::cout << "  TX-host MacTx: " << macTxBytes << " bytes" << "  (" << firstMacTxTime << "s -> "
-              << lastMacTxTime << "s)" << std::endl;
-    std::cout << "  RX-host MacRx: " << macRxBytes << " bytes" << "  (" << firstMacRxTime << "s -> "
-              << lastMacRxTime << "s)" << std::endl;
+    std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "  ** [MAC Layer]" << std::endl;
+    std::cout << "  TX-host MacTx: " << macTxBytes << " bytes  (" << firstMacTxTime << "s -> "
+              << lastMacTxTime << "s,  elapsed=" << macTxTime << "s)" << std::endl;
+    std::cout << "  RX-host MacRx: " << macRxBytes << " bytes  (" << firstMacRxTime << "s -> "
+              << lastMacRxTime << "s,  elapsed=" << macRxTime << "s)" << std::endl;
     std::cout << "  MAC TX Throughput: " << macTxThroughput << " Mbps" << std::endl;
     std::cout << "  MAC RX Throughput: " << macRxThroughput << " Mbps" << std::endl;
     std::cout << "======================================" << std::endl;
@@ -450,7 +449,7 @@ main(int argc, char* argv[])
 
     if (enablePcap)
     {
-        csma.EnablePcapAll("p4-psa-ipv4-forwarding");
+        csma.EnablePcapAll("p4-v1model-ipv4-forwarding");
     }
 
     // Run simulation

--- a/examples/p4-v1model-ipv4-forwarding.cc
+++ b/examples/p4-v1model-ipv4-forwarding.cc
@@ -193,7 +193,8 @@ PrintFinalThroughput()
     std::cout << "  TX: " << totalTxBytes << " bytes  (" << first_packet_send_time_tx << "s -> "
               << last_packet_send_time_tx << "s,  elapsed=" << send_time << "s)" << std::endl;
     std::cout << "  RX: " << totalRxBytes << " bytes  (" << first_packet_received_time_rx << "s -> "
-              << last_packet_received_time_rx << "s,  elapsed=" << elapsed_time << "s)" << std::endl;
+              << last_packet_received_time_rx << "s,  elapsed=" << elapsed_time << "s)"
+              << std::endl;
     std::cout << "  TX Throughput: " << finalTxThroughput << " Mbps" << std::endl;
     std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps" << std::endl;
     std::cout << "  ** [MAC Layer]" << std::endl;
@@ -227,7 +228,6 @@ main(int argc, char* argv[])
     double simDuration = 20.0;         ///< Total simulation time (s).
     int model = 0;          ///< 0 = P4 V1Model switch;  1 = standard NS-3 bridge (baseline).
     bool enablePcap = true; ///< Enable PCAP trace output.
-    int runnum = 0;         ///< Run index for batch experiments.
 
     // Paths resolved via P4SIM_DIR environment variable (portable).
     std::string p4SrcDir = GetP4ExamplePath() + "/simple_v1model";
@@ -252,7 +252,6 @@ main(int argc, char* argv[])
     cmd.AddValue("simDuration", "Total simulation duration (s, default 20)", simDuration);
     cmd.AddValue("model", "Switch model: 0=P4 V1Model, 1=NS-3 bridge baseline", model);
     cmd.AddValue("pcap", "Enable PCAP packet capture (true/false)", enablePcap);
-    cmd.AddValue("runnum", "Run index used for batch experiments", runnum);
     cmd.Parse(argc, argv);
 
     // Apply runtime-configurable timing after parsing

--- a/examples/p4-v1model-ipv4-forwarding.cc
+++ b/examples/p4-v1model-ipv4-forwarding.cc
@@ -23,7 +23,7 @@
  *          └─▲────────────┬─┘
  *            │            │
  *  ┌─────────┼─┐        ┌─▼─────────┐
- *  │  Host 1   │        │  Host     │
+ *  │  Host 1   │        │  Host  2  │
  *  └───────────┘        └───────────┘
  */
 
@@ -31,6 +31,7 @@
 #include "ns3/bridge-helper.h"
 #include "ns3/core-module.h"
 #include "ns3/csma-helper.h"
+#include "ns3/csma-net-device.h"
 #include "ns3/format-utils.h"
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
@@ -52,16 +53,22 @@ double client_stop_time = client_start_time + 3; // sending time 30s
 double sink_stop_time = client_stop_time + 5;
 double global_stop_time = sink_stop_time + 5;
 
-bool first_tx = true;
-bool first_rx = true;
-int counter_sender_10 = 10;
-int counter_receiver_10 = 10;
 double first_packet_send_time_tx = 0.0;
 double last_packet_send_time_tx = 0.0;
 double first_packet_received_time_rx = 0.0;
 double last_packet_received_time_rx = 0.0;
 uint64_t totalTxBytes = 0;
 uint64_t totalRxBytes = 0;
+
+// MAC-layer stats (data packets only, ARP <= 64 bytes skipped)
+uint64_t macTxBytes = 0;
+uint64_t macRxBytes = 0;
+double firstMacTxTime = 0.0;
+double lastMacTxTime = 0.0;
+double firstMacRxTime = 0.0;
+double lastMacRxTime = 0.0;
+bool firstMacTx = true;
+bool firstMacRx = true;
 
 // Convert IP address to hexadecimal format
 std::string
@@ -75,6 +82,47 @@ ConvertIpToHex(Ipv4Address ipAddr)
               << std::setw(2) << ((ip >> 8) & 0xFF)  // Third byte
               << std::setw(2) << (ip & 0xFF);        // Fourth byte
     return hexStream.str();
+}
+
+static void
+TxDropTrace(std::string label, Ptr<const Packet> p)
+{
+    NS_LOG_DEBUG(Simulator::Now().GetSeconds()
+                 << "s [" << label << "][DROP] size=" << p->GetSize());
+}
+
+static void
+MacTxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacTx] size=" << p->GetSize());
+    if (label == "TX-host" && p->GetSize() > 64)
+    {
+        if (firstMacTx)
+        {
+            firstMacTxTime = now;
+            firstMacTx = false;
+        }
+        lastMacTxTime = now;
+        macTxBytes += p->GetSize();
+    }
+}
+
+static void
+MacRxTrace(std::string label, Ptr<const Packet> p)
+{
+    double now = Simulator::Now().GetSeconds();
+    NS_LOG_DEBUG(now << "s [" << label << "][MacRx] size=" << p->GetSize());
+    if (label == "RX-host" && p->GetSize() > 64)
+    {
+        if (firstMacRx)
+        {
+            firstMacRxTime = now;
+            firstMacRx = false;
+        }
+        lastMacRxTime = now;
+        macRxBytes += p->GetSize();
+    }
 }
 
 // Convert MAC address to hexadecimal format
@@ -95,43 +143,30 @@ ConvertMacToHex(Address macAddr)
 }
 
 void
-TxCallback(Ptr<const Packet> packet)
+TxCallback(uint32_t dataSize, Ptr<const Packet> packet)
 {
-    if (first_tx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
+    // Here we filter out non-data packets (e.g., ARP) by checking the packet size against the
+    // expected data size. The system will first send ARP packets to resolve the MAC address, which
+    // are typically smaller than the application data packets. By only counting packets that match
+    // the expected data size, we can focus our throughput calculations on the actual application
+    // data being sent, providing a more accurate measure of the effective throughput of the system.
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_send_time_tx == 0.0)
         first_packet_send_time_tx = Simulator::Now().GetSeconds();
-        counter_sender_10--;
-        if (counter_sender_10 == 0)
-        {
-            first_tx = false;
-        }
-    }
-    else
-    {
-        totalTxBytes += packet->GetSize();
-        last_packet_send_time_tx = Simulator::Now().GetSeconds();
-    }
+    totalTxBytes += packet->GetSize();
+    last_packet_send_time_tx = Simulator::Now().GetSeconds();
 }
 
 void
-RxCallback(Ptr<const Packet> packet, const Address& addr)
+RxCallback(uint32_t dataSize, Ptr<const Packet> packet, const Address& addr)
 {
-    if (first_rx)
-    {
-        // here we just simple jump the first 10 pkts (include some of ARP packets)
+    if (packet->GetSize() != dataSize)
+        return; // skip ARP and other non-data packets
+    if (first_packet_received_time_rx == 0.0)
         first_packet_received_time_rx = Simulator::Now().GetSeconds();
-        counter_receiver_10--;
-        if (counter_receiver_10 == 0)
-        {
-            first_rx = false;
-        }
-    }
-    else
-    {
-        totalRxBytes += packet->GetSize();
-        last_packet_received_time_rx = Simulator::Now().GetSeconds();
-    }
+    totalRxBytes += packet->GetSize();
+    last_packet_received_time_rx = Simulator::Now().GetSeconds();
 }
 
 void
@@ -140,21 +175,35 @@ PrintFinalThroughput()
     double send_time = last_packet_send_time_tx - first_packet_send_time_tx;
     double elapsed_time = last_packet_received_time_rx - first_packet_received_time_rx;
 
+    // Both TX and RX throughput use send_time as denominator:
+    // RX elapsed_time can be shorter than send_time when the last sent packet
+    // is still in flight (pipeline effect), which would inflate RX throughput.
+    // Using send_time gives a fair apples-to-apples comparison.
     double finalTxThroughput = (totalTxBytes * 8.0) / (send_time * 1e6);
-    double finalRxThroughput = (totalRxBytes * 8.0) / (elapsed_time * 1e6);
-    std::cout << "client_start_time: " << first_packet_send_time_tx
-              << "client_stop_time: " << last_packet_send_time_tx
-              << "sink_start_time: " << first_packet_received_time_rx
-              << "sink_stop_time: " << last_packet_received_time_rx << std::endl;
+    double finalRxThroughput = (totalRxBytes * 8.0) / (send_time * 1e6);
+    double pktDeliveryRatio =
+        (totalTxBytes > 0) ? (double)totalRxBytes / totalTxBytes * 100.0 : 0.0;
+
+    double macTxTime = lastMacTxTime - firstMacTxTime;
+    // double macRxTime = lastMacRxTime - firstMacRxTime;
+    double macTxThroughput = (macTxTime > 0) ? (macTxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
+    double macRxThroughput = (macTxTime > 0) ? (macRxBytes * 8.0) / (macTxTime * 1e6) : 0.0;
 
     std::cout << "======================================" << std::endl;
     std::cout << "Final Simulation Results:" << std::endl;
-    std::cout << "Total Transmitted Bytes: " << totalTxBytes << " bytes in time " << send_time
-              << std::endl;
-    std::cout << "Total Received Bytes: " << totalRxBytes << " bytes in time " << elapsed_time
-              << std::endl;
-    std::cout << "Final Transmitted Throughput: " << finalTxThroughput << " Mbps" << std::endl;
-    std::cout << "Final Received Throughput: " << finalRxThroughput << " Mbps" << std::endl;
+    std::cout << "  ** [App Layer]  (window = send_time = " << send_time << "s)" << std::endl;
+    std::cout << "  TX: " << totalTxBytes << " bytes  |  RX: " << totalRxBytes
+              << " bytes  |  PDR: " << pktDeliveryRatio << "%" << std::endl;
+    std::cout << "  TX Throughput: " << finalTxThroughput << " Mbps" << std::endl;
+    std::cout << "  RX Throughput: " << finalRxThroughput << " Mbps  "
+              << "(RX elapsed=" << elapsed_time << "s)" << std::endl;
+    std::cout << "  ** [MAC Layer]  (window = macTxTime = " << macTxTime << "s)" << std::endl;
+    std::cout << "  TX-host MacTx: " << macTxBytes << " bytes" << "  (" << firstMacTxTime << "s -> "
+              << lastMacTxTime << "s)" << std::endl;
+    std::cout << "  RX-host MacRx: " << macRxBytes << " bytes" << "  (" << firstMacRxTime << "s -> "
+              << lastMacRxTime << "s)" << std::endl;
+    std::cout << "  MAC TX Throughput: " << macTxThroughput << " Mbps" << std::endl;
+    std::cout << "  MAC RX Throughput: " << macRxThroughput << " Mbps" << std::endl;
     std::cout << "======================================" << std::endl;
 }
 
@@ -174,7 +223,7 @@ main(int argc, char* argv[])
     uint32_t clientIndex = 0;          ///< Index of the sending host.
     uint32_t serverIndex = 1;          ///< Index of the receiving host.
     uint16_t serverPort = 9093;        ///< UDP destination port on the server.
-    uint32_t switchRate = 100000;      ///< P4 switch processing rate in packets per second.
+    uint32_t switchRate = 10000;       ///< P4 switch processing rate in packets per second.
     double flowDuration = 3.0;         ///< Duration of the OnOff flow (s).
     double simDuration = 20.0;         ///< Total simulation time (s).
     int model = 0;          ///< 0 = P4 V1Model switch;  1 = standard NS-3 bridge (baseline).
@@ -207,6 +256,10 @@ main(int argc, char* argv[])
     cmd.AddValue("runnum", "Run index used for batch experiments", runnum);
     cmd.Parse(argc, argv);
 
+    // Apply runtime-configurable timing after parsing
+    client_stop_time = client_start_time + flowDuration;
+    sink_stop_time = client_stop_time + 5.0;
+
     // ============================ topo -> network ============================
 
     P4TopologyReaderHelper p4TopoHelper;
@@ -234,7 +287,7 @@ main(int argc, char* argv[])
     // set default network link parameter
     CsmaHelper csma;
     csma.SetChannelAttribute("DataRate", StringValue(linkRate));
-    csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
+    csma.SetChannelAttribute("Delay", StringValue(linkDelay));
 
     NetDeviceContainer hostDevices;
     NetDeviceContainer switchDevices;
@@ -337,9 +390,9 @@ main(int argc, char* argv[])
     }
 
     // === Configuration for Link: h0 -----> h1 ===
-    unsigned int serverI = 1;
-    unsigned int clientI = 0;
-    uint16_t servPort = 9093; // UDP port for the server
+    unsigned int serverI = serverIndex;
+    unsigned int clientI = clientIndex;
+    uint16_t servPort = serverPort;
 
     // === Retrieve Server Address ===
     Ptr<Node> node = terminals.Get(serverI);
@@ -367,8 +420,33 @@ main(int argc, char* argv[])
     // === Setup Tracing ===
     Ptr<OnOffApplication> ptr_app1 =
         DynamicCast<OnOffApplication>(terminals.Get(clientI)->GetApplication(0));
-    ptr_app1->TraceConnectWithoutContext("Tx", MakeCallback(&TxCallback));
-    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx", MakeCallback(&RxCallback));
+    ptr_app1->TraceConnectWithoutContext("Tx", MakeBoundCallback(&TxCallback, (uint32_t)pktSize));
+    sinkApp1.Get(0)->TraceConnectWithoutContext("Rx",
+                                                MakeBoundCallback(&RxCallback, (uint32_t)pktSize));
+
+    // Attach MAC-level traces to the sender NIC
+    Ptr<CsmaNetDevice> txDev = DynamicCast<CsmaNetDevice>(terminals.Get(clientI)->GetDevice(0));
+    if (txDev)
+    {
+        txDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("TX-host")));
+    }
+
+    // Attach MAC-level traces to the receiver NIC
+    Ptr<CsmaNetDevice> rxDev = DynamicCast<CsmaNetDevice>(terminals.Get(serverI)->GetDevice(0));
+    if (rxDev)
+    {
+        rxDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("RX-host")));
+    }
 
     if (enablePcap)
     {
@@ -378,7 +456,7 @@ main(int argc, char* argv[])
     // Run simulation
     NS_LOG_INFO("Running simulation...");
     unsigned long simulate_start = getTickCount();
-    Simulator::Stop(Seconds(global_stop_time));
+    Simulator::Stop(Seconds(simDuration));
     Simulator::Run();
     Simulator::Destroy();
 


### PR DESCRIPTION
Fix the issue where the parameter is left unset, and add tracing at the MAC layer to output the final results.

1. Fix the bug [Issue15 ](https://github.com/HapCommSys/p4sim/issues/15) for setting the parameter in  `csma.SetChannelAttribute("Delay", StringValue(linkDelay));`
2. Add the MAC layer summary together with the Application layer results print for ns-3 scripts. For the calculations, the `ARP` packets will not be counted. :
```bash
# ./ns3 run p4-v1model-ipv4-forwarding
======================================
Final Simulation Results:
  ** [App Layer]  (window = send_time = 2.99467s)
  TX: 1124000 bytes  |  RX: 1124000 bytes  |  PDR: 100%
  TX Throughput: 3.00267 Mbps
  RX Throughput: 3.00267 Mbps  (RX elapsed=2.9883s)
  ** [MAC Layer]  (window = macTxTime = 2.98832s)
  TX-host MacTx: 1175704 bytes  (3.00901s -> 5.99733s)
  RX-host MacRx: 1175704 bytes  (3.00912s -> 5.99742s)
  MAC TX Throughput: 3.14746 Mbps
  MAC RX Throughput: 3.14746 Mbps
======================================

# For the case, with a larger latency of the link
# ./ns3 run "p4-v1model-ipv4-forwarding --linkDelay=5ms --flowDuration=0.2 --pcap=true"
======================================
Final Simulation Results:
  ** [App Layer]  (window = send_time = 0.194667s)
  TX: 74000 bytes  |  RX: 67000 bytes  |  PDR: 90.5405%
  TX Throughput: 3.0411 Mbps
  RX Throughput: 2.75342 Mbps  (RX elapsed=0.3544s)
  ** [MAC Layer]  (window = macTxTime = 0.168333s)
  TX-host MacTx: 70082 bytes  (3.029s -> 3.19733s)
  RX-host MacRx: 70082 bytes  (3.03911s -> 3.39351s)
  MAC TX Throughput: 3.33064 Mbps
  MAC RX Throughput: 3.33064 Mbps
======================================
```
PS: `ARP` packets are when we start the system simulation; the host uses them to find the MAC address based on the IP address.