### PR TITLE
integrate a p4-net-builder for user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ build_lib(
         helper/p4-topology-reader-helper.h
         helper/p4-p2p-helper.h
         helper/build-flowtable-helper.h
+        helper/p4-net-builder.h
     LIBRARIES_TO_LINK 
         ${libcore} 
         ${libnetwork}  

--- a/examples/p4-basic-controller.cc
+++ b/examples/p4-basic-controller.cc
@@ -46,6 +46,7 @@
 #include "ns3/network-module.h"
 #include "ns3/p4-controller.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -169,21 +170,6 @@ PrintFinalThroughput()
     std::cout << "======================================" << std::endl;
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -241,82 +227,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
     csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    // NetDeviceContainer hostDevices;
-    // NetDeviceContainer switchDevices;
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // ========================Print the Channel Type and NetDevice
     // Type========================

--- a/examples/p4-basic-example.cc
+++ b/examples/p4-basic-example.cc
@@ -46,6 +46,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -109,6 +110,22 @@ ConvertMacToHex(Address macAddr)
         hexStream << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(buffer[i]);
     }
     return hexStream.str();
+}
+
+static void
+LogNodeAddresses(const NodeContainer& terminals)
+{
+    NS_LOG_INFO("Node IP and MAC addresses:");
+    for (uint32_t i = 0; i < terminals.GetN(); ++i)
+    {
+        Ptr<Node> node = terminals.Get(i);
+        Ptr<Ipv4> ipv4Proto = node->GetObject<Ipv4>();
+        Ipv4Address ipAddr = ipv4Proto->GetAddress(1, 0).GetLocal();
+        Mac48Address mac = Mac48Address::ConvertFrom(node->GetDevice(0)->GetAddress());
+        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
+        NS_LOG_INFO("Node " << i << ": IP = " << ConvertIpToHex(ipAddr)
+                            << ", MAC = " << ConvertMacToHex(mac));
+    }
 }
 
 static void
@@ -212,21 +229,31 @@ PrintFinalThroughput()
     std::cout << "======================================" << std::endl;
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
+static void
+AttachCsmaMacTraces(const NodeContainer& terminals, uint32_t clientI, uint32_t serverI)
 {
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
+    Ptr<CsmaNetDevice> txDev = DynamicCast<CsmaNetDevice>(terminals.Get(clientI)->GetDevice(0));
+    if (txDev)
+    {
+        txDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("TX-host")));
+        txDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("TX-host")));
+    }
 
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
+    Ptr<CsmaNetDevice> rxDev = DynamicCast<CsmaNetDevice>(terminals.Get(serverI)->GetDevice(0));
+    if (rxDev)
+    {
+        rxDev->TraceConnectWithoutContext("MacTx",
+                                          MakeBoundCallback(&MacTxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacRx",
+                                          MakeBoundCallback(&MacRxTrace, std::string("RX-host")));
+        rxDev->TraceConnectWithoutContext("MacTxDrop",
+                                          MakeBoundCallback(&TxDropTrace, std::string("RX-host")));
+    }
+}
 
 int
 main(int argc, char* argv[])
@@ -283,84 +310,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
     csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    // NetDeviceContainer hostDevices;
-    // NetDeviceContainer switchDevices;
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
-
-    // ========================Print the Channel Type and NetDevice Type========================
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     InternetStackHelper internet;
     internet.Install(terminals);
@@ -377,32 +329,9 @@ main(int argc, char* argv[])
         hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
     }
 
-    //===============================  Print IP and MAC addresses===============================
-    NS_LOG_INFO("Node IP and MAC addresses:");
-    for (uint32_t i = 0; i < terminals.GetN(); ++i)
-    {
-        Ptr<Node> node = terminals.Get(i);
-        Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-        Ptr<NetDevice> netDevice = node->GetDevice(0);
+    LogNodeAddresses(terminals);
 
-        // Get the IP address
-        Ipv4Address ipAddr =
-            ipv4->GetAddress(1, 0)
-                .GetLocal(); // Interface index 1 corresponds to the first assigned IP
-
-        // Get the MAC address
-        Ptr<NetDevice> device = node->GetDevice(0); // Assuming the first device is the desired one
-        Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
-
-        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
-
-        // Convert to hexadecimal
-        std::string ipHex = ConvertIpToHex(ipAddr);
-        std::string macHex = ConvertMacToHex(mac);
-        NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
-    }
-
-    // Bridge or P4 switch configuration
+    // P4 switch configuration
     P4Helper p4SwitchHelper;
     p4SwitchHelper.SetDeviceAttribute("JsonPath", StringValue(p4JsonPath));
     p4SwitchHelper.SetDeviceAttribute("ChannelType", UintegerValue(0));
@@ -452,29 +381,7 @@ main(int argc, char* argv[])
     sinkApp1.Get(0)->TraceConnectWithoutContext("Rx",
                                                 MakeBoundCallback(&RxCallback, (uint32_t)pktSize));
 
-    // Attach MAC-level traces to the sender NIC
-    Ptr<CsmaNetDevice> txDev = DynamicCast<CsmaNetDevice>(terminals.Get(clientI)->GetDevice(0));
-    if (txDev)
-    {
-        txDev->TraceConnectWithoutContext("MacTx",
-                                          MakeBoundCallback(&MacTxTrace, std::string("TX-host")));
-        txDev->TraceConnectWithoutContext("MacRx",
-                                          MakeBoundCallback(&MacRxTrace, std::string("TX-host")));
-        txDev->TraceConnectWithoutContext("MacTxDrop",
-                                          MakeBoundCallback(&TxDropTrace, std::string("TX-host")));
-    }
-
-    // Attach MAC-level traces to the receiver NIC
-    Ptr<CsmaNetDevice> rxDev = DynamicCast<CsmaNetDevice>(terminals.Get(serverI)->GetDevice(0));
-    if (rxDev)
-    {
-        rxDev->TraceConnectWithoutContext("MacTx",
-                                          MakeBoundCallback(&MacTxTrace, std::string("RX-host")));
-        rxDev->TraceConnectWithoutContext("MacRx",
-                                          MakeBoundCallback(&MacRxTrace, std::string("RX-host")));
-        rxDev->TraceConnectWithoutContext("MacTxDrop",
-                                          MakeBoundCallback(&TxDropTrace, std::string("RX-host")));
-    }
+    AttachCsmaMacTraces(terminals, clientI, serverI);
 
     if (enableTracePcap)
     {

--- a/examples/p4-basic-tunnel.cc
+++ b/examples/p4-basic-tunnel.cc
@@ -27,6 +27,7 @@
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
 #include "ns3/p4-p2p-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -158,21 +159,6 @@ PrintFinalThroughput()
     std::cout << "======================================" << std::endl;
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -229,75 +215,9 @@ main(int argc, char* argv[])
     p4p2phelper.SetDeviceAttribute("DataRate", DataRateValue(DataRate(ns3_link_rate)));
     p4p2phelper.SetChannelAttribute("Delay", TimeValue(MilliSeconds(1)));
 
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            p4p2phelper.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, p4p2phelper, switchNodes, hostNodes);
     // ======================== Print the Channel Type and NetDevice Type ========================
 
     InternetStackHelper internet;

--- a/examples/p4-calc.cc
+++ b/examples/p4-calc.cc
@@ -23,6 +23,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -120,21 +121,6 @@ SendTestPacket(Ptr<NetDevice> sender,
     sender->SendFrom(packet, src, dst, protocol);
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -197,82 +183,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
     csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    // NetDeviceContainer hostDevices;
-    // NetDeviceContainer switchDevices;
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // ========================Print the Channel Type and NetDevice Type========================
 

--- a/examples/p4-controller-action-profile.cc
+++ b/examples/p4-controller-action-profile.cc
@@ -46,6 +46,7 @@
 #include "ns3/network-module.h"
 #include "ns3/p4-controller.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -169,21 +170,6 @@ PrintFinalThroughput()
     std::cout << "======================================" << std::endl;
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -241,82 +227,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
     csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    // NetDeviceContainer hostDevices;
-    // NetDeviceContainer switchDevices;
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // ========================Print the Channel Type and NetDevice
     // Type========================

--- a/examples/p4-firewall.cc
+++ b/examples/p4-firewall.cc
@@ -46,6 +46,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -105,21 +106,6 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -176,80 +162,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(ns3_link_rate));
     csma.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // ========================Print the Channel Type and NetDevice Type========================
 

--- a/examples/p4-link-monitoring.cc
+++ b/examples/p4-link-monitoring.cc
@@ -31,6 +31,7 @@
 #include "ns3/p4-helper.h"
 #include "ns3/p4-p2p-channel.h"
 #include "ns3/p4-p2p-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 #include "ns3/packet-sink-helper.h"
 #include "ns3/packet.h"
@@ -73,21 +74,6 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -141,75 +127,9 @@ main(int argc, char* argv[])
     P4PointToPointHelper p4p2phelper;
     p4p2phelper.SetChannelAttribute("Delay", TimeValue(MilliSeconds(0.01)));
 
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            p4p2phelper.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, p4p2phelper, switchNodes, hostNodes);
     // ======================== Print the Channel Type and NetDevice Type ========================
 
     InternetStackHelper internet;

--- a/examples/p4-source-routing.cc
+++ b/examples/p4-source-routing.cc
@@ -28,6 +28,7 @@
 #include "ns3/loopback-net-device.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 #include "ns3/packet-socket-address.h"
 #include "ns3/packet-socket-factory.h"
@@ -296,21 +297,6 @@ ConvertMacToHex(Address macAddr)
     return hexStream.str();
 }
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 int
 main(int argc, char* argv[])
@@ -383,80 +369,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(linkRate));
     csma.SetChannelAttribute("Delay", StringValue(linkDelay));
 
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-            csma.SetChannelAttribute("DataRate", StringValue(dataRate));
-        if (iter->GetAttributeFailSafe("Delay", delay))
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     InternetStackHelper internet;
     internet.Install(terminals);

--- a/examples/p4-spine-leaf-topo.cc
+++ b/examples/p4-spine-leaf-topo.cc
@@ -26,6 +26,7 @@
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
 #include "ns3/p4-p2p-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -43,21 +44,6 @@ double client_stop_time = client_start_time + 60;
 double sink_stop_time = client_stop_time + 5;
 double global_stop_time = sink_stop_time + 5;
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 struct SwitchInfoTracing
 {
@@ -308,8 +294,8 @@ main(int argc, char* argv[])
     p4p2p.SetChannelAttribute("Delay", TimeValue(NanoSeconds(10)));
 
     P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
     unsigned int fromIndex, toIndex;
     std::string dataRate, delay;
     for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)

--- a/examples/p4-topo-fattree.cc
+++ b/examples/p4-topo-fattree.cc
@@ -28,6 +28,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -45,21 +46,6 @@ double client_stop_time = client_start_time + 2; // Client will send packets for
 double sink_stop_time = client_stop_time + 5;
 double global_stop_time = sink_stop_time + 5;
 
-// ============================ data struct ============================
-struct SwitchNodeC_t
-{
-    NetDeviceContainer switchDevices;
-    std::vector<std::string> switchPortInfos;
-};
-
-struct HostNodeC_t
-{
-    NetDeviceContainer hostDevice;
-    Ipv4InterfaceContainer hostIpv4;
-    unsigned int linkSwitchIndex;
-    unsigned int linkSwitchPort;
-    std::string hostIpv4Str;
-};
 
 // Convert IP address to hexadecimal format
 std::string
@@ -174,86 +160,9 @@ main(int argc, char* argv[])
     // p4p2p.SetDeviceAttribute("DataRate", DataRateValue(DataRate("10Gbps")));
     // p4p2p.SetChannelAttribute("Delay", TimeValue(NanoSeconds(10)));
 
-    P4TopologyReader::ConstLinksIterator_t iter;
-    SwitchNodeC_t switchNodes[switchNum];
-    HostNodeC_t hostNodes[hostNum];
-    unsigned int fromIndex, toIndex;
-    std::string dataRate, delay;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        if (iter->GetAttributeFailSafe("DataRate", dataRate))
-        {
-            csma.SetChannelAttribute("DataRate", DataRateValue(DataRate(dataRate)));
-            NS_LOG_INFO("DataRate: " << dataRate);
-        }
-        if (iter->GetAttributeFailSafe("Delay", delay))
-        {
-            csma.SetChannelAttribute("Delay", StringValue(delay));
-            NS_LOG_INFO("Delay: " << delay);
-        }
-
-        fromIndex = iter->GetFromIndex();
-        toIndex = iter->GetToIndex();
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            NS_LOG_INFO("*** Link from  switch " << fromIndex << " to  switch " << toIndex
-                                                 << " with data rate " << dataRate << " and delay "
-                                                 << delay);
-
-            unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-            unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-            switchNodes[fromIndex].switchPortInfos.push_back("s" + UintToString(toIndex) + "_" +
-                                                             UintToString(toSwitchPortNumber));
-
-            switchNodes[toIndex].switchDevices.Add(link.Get(1));
-            switchNodes[toIndex].switchPortInfos.push_back("s" + UintToString(fromIndex) + "_" +
-                                                           UintToString(fromSwitchPortNumber));
-        }
-        else
-        {
-            if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-            {
-                NS_LOG_INFO("*** Link from switch " << fromIndex << " to  host" << toIndex
-                                                    << " with data rate " << dataRate
-                                                    << " and delay " << delay);
-
-                unsigned int fromSwitchPortNumber = switchNodes[fromIndex].switchDevices.GetN();
-                switchNodes[fromIndex].switchDevices.Add(link.Get(0));
-                switchNodes[fromIndex].switchPortInfos.push_back("h" +
-                                                                 UintToString(toIndex - switchNum));
-
-                hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
-                hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
-                hostNodes[toIndex - switchNum].linkSwitchPort = fromSwitchPortNumber;
-            }
-            else
-            {
-                if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-                {
-                    NS_LOG_INFO("*** Link from host " << fromIndex << " to  switch" << toIndex
-                                                      << " with data rate " << dataRate
-                                                      << " and delay " << delay);
-                    unsigned int toSwitchPortNumber = switchNodes[toIndex].switchDevices.GetN();
-                    switchNodes[toIndex].switchDevices.Add(link.Get(1));
-                    switchNodes[toIndex].switchPortInfos.push_back(
-                        "h" + UintToString(fromIndex - switchNum));
-
-                    hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
-                    hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
-                    hostNodes[fromIndex - switchNum].linkSwitchPort = toSwitchPortNumber;
-                }
-                else
-                {
-                    NS_LOG_ERROR("link error!");
-                    abort();
-                }
-            }
-        }
-    }
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // // view host link info
     // for (unsigned int i = 0; i < hostNum; i++)

--- a/examples/p4-v1model-ipv4-forwarding.cc
+++ b/examples/p4-v1model-ipv4-forwarding.cc
@@ -36,6 +36,7 @@
 #include "ns3/internet-module.h"
 #include "ns3/network-module.h"
 #include "ns3/p4-helper.h"
+#include "ns3/p4-net-builder.h"
 #include "ns3/p4-topology-reader-helper.h"
 
 #include <filesystem>
@@ -140,6 +141,22 @@ ConvertMacToHex(Address macAddr)
         hexStream << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(buffer[i]);
     }
     return hexStream.str();
+}
+
+static void
+LogNodeAddresses(const NodeContainer& terminals)
+{
+    NS_LOG_INFO("Node IP and MAC addresses:");
+    for (uint32_t i = 0; i < terminals.GetN(); ++i)
+    {
+        Ptr<Node> node = terminals.Get(i);
+        Ptr<Ipv4> ipv4Proto = node->GetObject<Ipv4>();
+        Ipv4Address ipAddr = ipv4Proto->GetAddress(1, 0).GetLocal();
+        Mac48Address mac = Mac48Address::ConvertFrom(node->GetDevice(0)->GetAddress());
+        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
+        NS_LOG_INFO("Node " << i << ": IP = " << ConvertIpToHex(ipAddr)
+                            << ", MAC = " << ConvertMacToHex(mac));
+    }
 }
 
 void
@@ -287,37 +304,9 @@ main(int argc, char* argv[])
     csma.SetChannelAttribute("DataRate", StringValue(linkRate));
     csma.SetChannelAttribute("Delay", StringValue(linkDelay));
 
-    NetDeviceContainer hostDevices;
-    NetDeviceContainer switchDevices;
-    P4TopologyReader::ConstLinksIterator_t iter;
-    for (iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); iter++)
-    {
-        NetDeviceContainer link =
-            csma.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
-
-        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
-        {
-            switchDevices.Add(link.Get(0));
-            switchDevices.Add(link.Get(1));
-        }
-        else if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
-        {
-            switchDevices.Add(link.Get(0));
-            hostDevices.Add(link.Get(1));
-        }
-        else if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
-        {
-            hostDevices.Add(link.Get(0));
-            switchDevices.Add(link.Get(1));
-        }
-        else
-        {
-            NS_LOG_ERROR("link error!");
-            abort();
-        }
-    }
-
-    // ========================Print the Channel Type and NetDevice Type========================
+    std::vector<SwitchNodeC_t> switchNodes(switchNum);
+    std::vector<HostNodeC_t> hostNodes(hostNum);
+    BuildNetworkFromTopology(topoReader, csma, switchNodes, hostNodes);
 
     // Install the Internet stack
     InternetStackHelper internet;
@@ -336,30 +325,7 @@ main(int argc, char* argv[])
         hostIpv4[i] = Uint32IpToHex(terminalInterfaces[i].GetAddress(0).Get());
     }
 
-    //===============================  Print IP and MAC addresses===============================
-    NS_LOG_INFO("Node IP and MAC addresses:");
-    for (uint32_t i = 0; i < terminals.GetN(); ++i)
-    {
-        Ptr<Node> node = terminals.Get(i);
-        Ptr<Ipv4> ipv4 = node->GetObject<Ipv4>();
-        Ptr<NetDevice> netDevice = node->GetDevice(0);
-
-        // Get the IP address
-        Ipv4Address ipAddr =
-            ipv4->GetAddress(1, 0)
-                .GetLocal(); // Interface index 1 corresponds to the first assigned IP
-
-        // Get the MAC address
-        Ptr<NetDevice> device = node->GetDevice(0); // Assuming the first device is the desired one
-        Mac48Address mac = Mac48Address::ConvertFrom(device->GetAddress());
-
-        NS_LOG_INFO("Node " << i << ": IP = " << ipAddr << ", MAC = " << mac);
-
-        // Convert to hexadecimal
-        std::string ipHex = ConvertIpToHex(ipAddr);
-        std::string macHex = ConvertMacToHex(mac);
-        NS_LOG_INFO("Node " << i << ": IP = " << ipHex << ", MAC = " << macHex);
-    }
+    LogNodeAddresses(terminals);
 
     // Bridge or P4 switch configuration
     if (model == 0)
@@ -376,14 +342,14 @@ main(int argc, char* argv[])
                                         // safe default for this simple test.
 
         for (uint32_t i = 0; i < switchNum; ++i)
-            p4Helper.Install(switchNode.Get(i), switchDevices);
+            p4Helper.Install(switchNode.Get(i), switchNodes[i].switchDevices);
     }
     else
     {
         BridgeHelper bridge;
         for (unsigned int i = 0; i < switchNum; i++)
         {
-            bridge.Install(switchNode.Get(i), switchDevices);
+            bridge.Install(switchNode.Get(i), switchNodes[i].switchDevices);
         }
     }
 

--- a/helper/p4-net-builder.h
+++ b/helper/p4-net-builder.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025 TU Dresden
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mingyu Ma <mingyu.ma@tu-dresden.de>
+ */
+
+#ifndef P4_NET_BUILDER_H
+#define P4_NET_BUILDER_H
+
+#include "ns3/abort.h"
+#include "ns3/ipv4-interface-container.h"
+#include "ns3/net-device-container.h"
+#include "ns3/node-container.h"
+#include "ns3/p4-topology-reader.h"
+
+#include <string>
+#include <vector>
+
+namespace ns3
+{
+
+/**
+ * \ingroup p4sim
+ *
+ * \brief Per-switch bookkeeping used when building a P4 network from a topology file.
+ *
+ * Holds the NetDeviceContainer for the switch's ports and a human-readable
+ * description of each port's peer (e.g. "h2" or "s1_0").
+ */
+struct SwitchNodeC_t
+{
+    NetDeviceContainer switchDevices;
+    std::vector<std::string> switchPortInfos;
+};
+
+/**
+ * \ingroup p4sim
+ *
+ * \brief Per-host bookkeeping used when building a P4 network from a topology file.
+ *
+ * Records the single NetDevice attached to the host, the switch it connects to,
+ * and the port number on that switch.
+ */
+struct HostNodeC_t
+{
+    NetDeviceContainer hostDevice;
+    Ipv4InterfaceContainer hostIpv4;
+    unsigned int linkSwitchIndex;
+    unsigned int linkSwitchPort;
+    std::string hostIpv4Str;
+};
+
+/**
+ * \brief Install CSMA or P2P links from a topology file and populate switch/host bookkeeping.
+ *
+ * Iterates over every link in \p topoReader, calls \p channelHelper.Install() for each
+ * one, and fills \p switchNodes and \p hostNodes with the resulting NetDevices and
+ * port-adjacency information.  All channel attributes (DataRate, Delay, etc.) are
+ * expected to be pre-configured on \p channelHelper before calling this function;
+ * per-link attribute overrides from the topology file are not applied here, because
+ * DataRate and Delay semantics differ between CsmaHelper and P4PointToPointHelper.
+ *
+ * \tparam ChannelHelper  Any helper that exposes SetChannelAttribute() and
+ *                        Install(NodeContainer), e.g. CsmaHelper or P4PointToPointHelper.
+ *
+ * \param topoReader   Topology reader whose links have already been loaded.
+ * \param channelHelper Channel/link helper, pre-configured with the default DataRate.
+ * \param switchNodes  Output vector, must be pre-sized to switchNum entries.
+ * \param hostNodes    Output vector, must be pre-sized to hostNum entries.
+ */
+template <typename ChannelHelper>
+void
+BuildNetworkFromTopology(Ptr<P4TopologyReader> topoReader,
+                         ChannelHelper& channelHelper,
+                         std::vector<SwitchNodeC_t>& switchNodes,
+                         std::vector<HostNodeC_t>& hostNodes)
+{
+    const unsigned int switchNum = topoReader->GetSwitchNodeContainer().GetN();
+
+    for (auto iter = topoReader->LinksBegin(); iter != topoReader->LinksEnd(); ++iter)
+    {
+        const unsigned int fromIndex = iter->GetFromIndex();
+        const unsigned int toIndex = iter->GetToIndex();
+        NetDeviceContainer link =
+            channelHelper.Install(NodeContainer(iter->GetFromNode(), iter->GetToNode()));
+
+        if (iter->GetFromType() == 's' && iter->GetToType() == 's')
+        {
+            unsigned int fromPort = switchNodes[fromIndex].switchDevices.GetN();
+            unsigned int toPort = switchNodes[toIndex].switchDevices.GetN();
+            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+            switchNodes[fromIndex].switchPortInfos.push_back(
+                "s" + std::to_string(toIndex) + "_" + std::to_string(toPort));
+            switchNodes[toIndex].switchDevices.Add(link.Get(1));
+            switchNodes[toIndex].switchPortInfos.push_back(
+                "s" + std::to_string(fromIndex) + "_" + std::to_string(fromPort));
+        }
+        else if (iter->GetFromType() == 's' && iter->GetToType() == 'h')
+        {
+            unsigned int fromPort = switchNodes[fromIndex].switchDevices.GetN();
+            switchNodes[fromIndex].switchDevices.Add(link.Get(0));
+            switchNodes[fromIndex].switchPortInfos.push_back(
+                "h" + std::to_string(toIndex - switchNum));
+            hostNodes[toIndex - switchNum].hostDevice.Add(link.Get(1));
+            hostNodes[toIndex - switchNum].linkSwitchIndex = fromIndex;
+            hostNodes[toIndex - switchNum].linkSwitchPort = fromPort;
+        }
+        else if (iter->GetFromType() == 'h' && iter->GetToType() == 's')
+        {
+            unsigned int toPort = switchNodes[toIndex].switchDevices.GetN();
+            switchNodes[toIndex].switchDevices.Add(link.Get(1));
+            switchNodes[toIndex].switchPortInfos.push_back(
+                "h" + std::to_string(fromIndex - switchNum));
+            hostNodes[fromIndex - switchNum].hostDevice.Add(link.Get(0));
+            hostNodes[fromIndex - switchNum].linkSwitchIndex = toIndex;
+            hostNodes[fromIndex - switchNum].linkSwitchPort = toPort;
+        }
+        else
+        {
+            NS_ABORT_MSG("BuildNetworkFromTopology: unsupported link type '"
+                         << iter->GetFromType() << "' -> '" << iter->GetToType() << "'");
+        }
+    }
+}
+
+} // namespace ns3
+
+#endif /* P4_NET_BUILDER_H */


### PR DESCRIPTION
This PR introduces `P4NetBuilder`, a reusable helper (`helper/p4-net-builder.h`) that centralizes the boilerplate topology-setup logic previously duplicated across all example scripts.

Every example in `examples/` was independently implementing the same ~80–100 lines of code to iterate over topology links, install `CSMA/P2P` channels, and populate per-switch and per-host bookkeeping. This made examples harder to read and meant any fix had to be applied in 12+ places.

**Changes**
- New: `helper/p4-net-builder.h` — adds two bookkeeping structs (`SwitchNodeC_t`, `HostNodeC_t`) and a templated function `BuildNetworkFromTopology<ChannelHelper>(...)` that wires up all links from a `P4TopologyReader` into the correct switch ports and host devices.
- Refactored: All 12 example scripts now call `BuildNetworkFromTopology()` instead of reimplementing it, reducing ~927 lines of duplicated setup code down to a shared 141-line header.
- `CMakeLists.txt`: Updated to include the new helper file.